### PR TITLE
Run the application on any local port

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The data explorer is an open source point-and-click interface for querying and v
   2. Add your Keen IO keys to demo/index.html
   3. `npm install`
   4. `npm -g install gulp` (if needed)
-  5. `gulp`
-  6. You can now view the demo locally at `http://localhost:8081/explorer`.
+  5. `gulp` or `export PORT=8082; gulp`
+  6. You can now view the demo locally at `http://localhost:8081/explorer` or your specified port.
 
 ### 1. Get your project ID & API keys
 If you haven’t done so already, [login to Keen IO to create a project](https://keen.io/add-project) for your app. You'll need a [Keen IO account](https://keen.io/signup?s=explorer) to create a project. The Project ID and API Keys are available on the Project Overview page. You will need these for the next steps.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('test:unit:run', function () {
 gulp.task('connect', function () {
   connect.server({
     root: [__dirname, 'demo', 'dist'],
-    port: 8081,
+    port: process.env.PORT || 8081,
     middleware: function(connect, opt) {
       return [ historyApiFallback ];
     }


### PR DESCRIPTION
Thanks for open-sourcing this project, we use Keen at ft.com to power some of our [product dashboards](https://github.com/Financial-Times/next-beacon-dashboard).

#### What does this PR do?

Allows people who have _other things_ running on 8081 to specify an alternate port to run the app on.

#### How should this be manually tested?

`export PORT=5001; gulp;` & `curl -i localhost:5001` 
