### PR TITLE
Correct plural suffix when changing relative time amount

### DIFF
--- a/client/js/app/components/common/relative_picker.js
+++ b/client/js/app/components/common/relative_picker.js
@@ -36,10 +36,11 @@ var RelativePicker = React.createClass({
 
     if (hasRelativeTimeframe(this.props.model)) {
       var subIntervalCopy = FormatUtils.singularize(time.sub_timeframe, time.amount);
+      var timeAmountPluralSuffix = time.amount > 1 ? 's' : '';
       var relativityCopy = time.relativity == 'this' ? 'including' : 'excluding';
       var singularCurrentInterval = FormatUtils.singularize(subIntervalCopy);
 
-      return (<p className="help-block">The last {time.amount} {subIntervalCopy} <b>{relativityCopy}</b> the current {singularCurrentInterval}.</p>);
+      return (<p className="help-block">The last {time.amount} {subIntervalCopy}{timeAmountPluralSuffix} <b>{relativityCopy}</b> the current {singularCurrentInterval}.</p>);
     }
   },
 


### PR DESCRIPTION
# What's this PR do?
This PR, fixes #7, small plural wording in the description text of relative time frame changer. 

# Where should the reviewer start?
relative_picker.js line 39 and 41

# How should this be manually tested?
go to relative time frame changer UI, and type 1 and 2 in the time amount input,  see the difference it makes. Or see the gif below

# Screenshot
http://g.recordit.co/Lme5HMhBjk.gif

Note: gulp test:unit is passing but I could not run gulp test:functional because raises following error:
"ReferenceError: mochaSelenium is not defined..."