### PR TITLE
Visit Duration now defaults to pie chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
           </a>
         </div>
         <div class="col-sm-4">
-          <a name="preset-visit-duration" class="explorer-preset" href="?query%5Bevent_collection%5D=leave&query%5Banalysis_type%5D=average&query%5Btarget_property%5D=sinceLoad&query%5Bgroup_by%5D=page.path&query%5Btimezone%5D=UTC&query%5Bfilters%5D%5B0%5D%5Bproperty_name%5D=page.path&query%5Bfilters%5D%5B0%5D%5Boperator%5D=contains&query%5Bfilters%5D%5B0%5D%5Bproperty_value%5D=%2Fblog&query%5Bfilters%5D%5B0%5D%5Bcoercion_type%5D=String&query%5Btimeframe%5D=this_1_weeks&visualization%5Bchart_type%5D=barchart#demo">
+          <a name="preset-visit-duration" class="explorer-preset" href="?query%5Bevent_collection%5D=leave&query%5Banalysis_type%5D=average&query%5Btarget_property%5D=sinceLoad&query%5Bgroup_by%5D=page.path&query%5Btimezone%5D=UTC&query%5Bfilters%5D%5B0%5D%5Bproperty_name%5D=page.path&query%5Bfilters%5D%5B0%5D%5Boperator%5D=contains&query%5Bfilters%5D%5B0%5D%5Bproperty_value%5D=%2Fblog&query%5Bfilters%5D%5B0%5D%5Bcoercion_type%5D=String&query%5Btimeframe%5D=this_1_weeks&visualization%5Bchart_type%5D=piechart#demo">
             <h3>Visit duration</h3>
             <span class="preset-description">Discover the average time visitors spend on the website.</span>
           </a>


### PR DESCRIPTION
Sets the default query view for `Visit Duration` to a pie chart.

![screen shot 2015-08-14 at 5 03 37 pm](https://cloud.githubusercontent.com/assets/6183404/9286347/741c1b98-42a6-11e5-8fd4-c13a6aaa1dc2.png)

