### PR TITLE
Funnel data model

### DIFF
--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -84,6 +84,35 @@ function _getDefaultFilterCoercionType(explorer, filter) {
 }
 
 /**
+ * Runs through the changeset and moves data around if necessary
+ * @param {Object} explorer   The explorer model that is being updated
+ * @param {Object} updates    The updated explorer model
+ * @return {Object}           The new set of updates
+ */
+function _prepareUpdates(explorer, updates) {
+  var newModel = _.assign({}, explorer, updates);
+
+  _removeEmailExtractionFields(explorer, newModel);
+
+  return newModel;
+}
+
+/**
+ * Removes fields from email extractions
+ * @param {Object} explorer   The explorer model that is being updated
+ * @param {Object} newModel   The updated explorer model
+ * @return {Object}           The new set of updates
+ */
+function _removeEmailExtractionFields(explorer, newModel) {
+  if (!ExplorerUtils.isEmailExtraction(newModel)) {
+    newModel.query.latest = null;
+    newModel.query.email = null;
+  }
+
+  return newModel;
+}
+
+/**
  * Looks at updates about to be made to a filter and performs a series of operations to
  * change the filter values depending on the coercion_type, operator and type of property_value.
  * @param  {Object} explorer  The explorer model that owns the filter to be updated
@@ -128,13 +157,8 @@ function _create(attrs) {
 }
 
 function _update(id, updates) {
-  var newModel = _.assign({}, _explorers[id], updates);
-  // If we're no longer doing an email extraction, remove the latest and email field.
-  // FIXME: Does this belong here? Maybe this should be in the onChange callback rather than hard-bound to the model.
-  if (!ExplorerUtils.isEmailExtraction(newModel)) {
-    newModel.query.latest = null;
-    newModel.query.email = null;
-  }
+  var newModel = _prepareUpdates(_explorers[id], updates);
+
   if (updates.id && updates.id !== id) {
     _explorers[updates.id] = newModel;
     delete _explorers[id];

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -110,19 +110,19 @@ function _prepareUpdates(explorer, updates) {
   var newModel = _.assign({}, explorer, updates);
 
   newModel = _removeEmailExtractionFields(explorer, newModel);
-  newModel = _migrateFunnelSteps(explorer, newModel);
+  newModel = _migrateToFunnel(explorer, newModel);
+  newModel = _migrateFromFunnel(explorer, newModel);
 
   return newModel;
 }
 
 /**
  * If the query got changed to a funnel, move the step-specific parameters to a steps object.
- * and vice versa if it got changed FROM a funnel
  * @param {Object} explorer The explorer model that is being updated
  * @param {Object} newModel The updated explorer model
  * @return {Object}         The new set of updates
  */
-function _migrateFunnelSteps(explorer, newModel) {
+function _migrateToFunnel(explorer, newModel) {
   var sharedProperties = ['event_collection', 'time', 'timezone', 'filters']
   if(newModel.query.analysis_type === 'funnel' && explorer.query.analysis_type !== 'funnel') {
     // Changing TO funnels
@@ -143,8 +143,20 @@ function _migrateFunnelSteps(explorer, newModel) {
     }
 
     newModel.query.steps = [firstStep];
+  }
 
-  } else if (newModel.query.analysis_type !== 'funnel' && explorer.query.analysis_type === 'funnel') {
+  return newModel;
+}
+
+/**
+ * If the query got changed from a funnel, move the applicable parameters out to the root query
+ * @param {Object} explorer The explorer model that is being updated
+ * @param {Object} newModel The updated explorer model
+ * @return {Object}         The new set of updates
+ */
+function _migrateFromFunnel(explorer, newModel) {
+  var sharedProperties = ['event_collection', 'time', 'timezone', 'filters']
+  if (newModel.query.analysis_type !== 'funnel' && explorer.query.analysis_type === 'funnel') {
     // Changing FROM funnels
     var activeStep = _.find(explorer.query.steps, function (step) {
       return step.active

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -130,14 +130,14 @@ function _migrateFunnelSteps(explorer, newModel) {
     firstStep.active = true;
 
     _.each(sharedProperties, function (key) {
-      if(typeof(explorer.query[key]) !== 'undefined' && explorer.query[key] !== null) {
+      if(!_.isUndefined(explorer.query[key]) && !_.isNull(explorer.query[key])) {
         firstStep[key] = explorer.query[key] 
       }      
 
       delete newModel.query[key]
     });
 
-    if(typeof(explorer.query.target_property) !== 'undefined' && explorer.query.target_property !== null) {
+    if(!_.isUndefined(explorer.query.target_property) && !_.isNull(explorer.query.target_property)) {
       firstStep.actor_property = explorer.query.target_property;
       delete explorer.query.target_property;
     }
@@ -151,12 +151,12 @@ function _migrateFunnelSteps(explorer, newModel) {
     });
 
     _.each(sharedProperties, function (key) {
-      if(typeof(activeStep[key]) !== 'undefined') {
+      if(!_.isUndefined(activeStep[key])) {
         newModel.query[key] = activeStep[key];
       }
     });
 
-    if(activeStep.actor_property !== null) {
+    if(!_.isNull(activeStep.actor_property)) {
       newModel.query.target_property = activeStep.actor_property;
     }
 


### PR DESCRIPTION
@aroc 

### What does this PR do? How does it affect users?
This adds the `ExplorerStore` logic for switching to & from funnel analysis types. Properties should flow in and out of the steps property when switching analysis types.

There's also a small refactor to use a set of update preparation functions, rather than making the `_update` function super chaotic.

### How should this be tested (feature switches, URLs, special user permissions)?
Well, unfortunately, you can't. There is no functional way to actually touch this code, because we don't actually have a funnel analysis_type yet. I'd suggest reading the tests thoroughly. If those make sense, and pass in CI, then we should be golden.