### PR TITLE
QueryBuilder should place step parameters on the active step

### DIFF
--- a/client/js/app/components/explorer/query_builder/index.js
+++ b/client/js/app/components/explorer/query_builder/index.js
@@ -44,10 +44,10 @@ var QueryBuilder = React.createClass({
 
     if(_.isPlainObject(update)) {
       for(key in update) {
-        newModel.query[key] = update[key];
+        this.placeUpdatedProperty(newModel, key, update[key]);
       }
     } else {
-      newModel.query[update] = value;
+      this.placeUpdatedProperty(newModel, update, value);
     }
 
     ExplorerActions.update(this.props.model.id, newModel);
@@ -57,6 +57,27 @@ var QueryBuilder = React.createClass({
 
   getEventPropertyNames: function()  {
     return ProjectUtils.getEventCollectionPropertyNames(this.props.project, this.props.model.query.event_collection);
+  },
+
+  placeUpdatedProperty: function(updates, key, value) {
+    var stepParameters = [
+      'event_collection',
+      'actor_property',
+      'time',
+      'timezone',
+      'optional',
+      'inverted'
+    ];
+
+    if(updates.query.analysis_type === 'funnel' && _.includes(stepParameters, key)) {
+      var activeStepIndex = _.findIndex(updates.query.steps, function (step) {
+        return step.active;
+      });
+
+      updates.query.steps[activeStepIndex][key] = value;
+    } else {
+      updates.query[key] = value;
+    }
   },
 
   updateGroupBy: function(updates) {

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -122,6 +122,10 @@ function _prepareUpdates(explorer, updates) {
 
 /**
  * If the query got changed to a funnel, move the step-specific parameters to a steps object.
+<<<<<<< 3777b8a6b8fec2695da874e5d7962e0ce0d733de
+=======
+ * and vice versa if it got changed FROM a funnel
+>>>>>>> move properties around when changing to/from funnels
  * @param {Object} explorer The explorer model that is being updated
  * @param {Object} newModel The updated explorer model
  * @return {Object}         The new set of updates

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -122,10 +122,6 @@ function _prepareUpdates(explorer, updates) {
 
 /**
  * If the query got changed to a funnel, move the step-specific parameters to a steps object.
-<<<<<<< 3777b8a6b8fec2695da874e5d7962e0ce0d733de
-=======
- * and vice versa if it got changed FROM a funnel
->>>>>>> move properties around when changing to/from funnels
  * @param {Object} explorer The explorer model that is being updated
  * @param {Object} newModel The updated explorer model
  * @return {Object}         The new set of updates

--- a/test/unit/components/explorer/query_builder/index_spec.js
+++ b/test/unit/components/explorer/query_builder/index_spec.js
@@ -271,4 +271,71 @@ describe('components/explorer/query_builder/index', function() {
     });
   });
 
+  describe('event callbacks', function () {
+    describe('handleChange', function () {
+      before(function () {
+        this.stub = sinon.stub(ExplorerActions, 'update');
+      });
+
+      after(function () {
+        ExplorerActions.update.restore();
+      });
+
+      beforeEach(function () {
+        this.stub.reset();
+      });
+
+      describe('should move properties into the active step', function () {
+        beforeEach(function () {
+          this.stub.reset();
+          this.model.query.analysis_type = 'funnel'
+          this.model.query.steps = [{
+            active: true 
+          }]
+          this.component.setProps({
+            model: this.model
+          });;
+        });
+
+
+        it('event_collection', function () {
+          this.component.handleChange('event_collection', 'jumps');
+          assert.strictEqual(this.stub.getCall(0).args[1].query.steps[0].event_collection, 'jumps');
+        });
+
+        it('actor_property', function () {
+          this.component.handleChange('actor_property', 'site_id');
+          assert.strictEqual(this.stub.getCall(0).args[1].query.steps[0].actor_property, 'site_id');
+        });
+
+        it('time', function () {
+          this.component.handleChange('time', {
+            relativity: 'this',
+            amount: 100,
+            sub_timeframe: 'hours'            
+          });
+          assert.deepEqual(this.stub.getCall(0).args[1].query.steps[0].time, {
+            relativity: 'this',
+            amount: 100,
+            sub_timeframe: 'hours'            
+          });
+        });
+
+        it('timezone', function () {
+          this.component.handleChange('timezone', 'America/Central');
+          assert.strictEqual(this.stub.getCall(0).args[1].query.steps[0].timezone, 'America/Central');
+        });
+
+        it('optional', function() {
+          this.component.handleChange('optional', true);
+          assert.strictEqual(this.stub.getCall(0).args[1].query.steps[0].optional, true);
+        });
+
+        it('inverted', function() {
+          this.component.handleChange('inverted', true);
+          assert.strictEqual(this.stub.getCall(0).args[1].query.steps[0].inverted, true);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

This adds a bit of logic to the `QueryBuilder` component to know how/where to place parameters when updating the query. If it's a funnel, a certain set of properties need to be placed on the active step, while other properties can continue to be placed on the root query.

For the record, this is gonna get real messy if we ever start allowing timeframes on both the step and the root query. I'm gonna try not the think about that yet :)

### How should this be tested (feature switches, URLs, special user permissions)?

Again, this doesn't affect the actual experience at all yet, because we don't have a funnel analysis type. The best way to test this is to give a thorough read of the unit tests I added, make sure they seem sane, and trust that the CI ran them.

### What makes you uneasy about this PR?

The function `placeUpdatedProperty` just feels... weird. Like, not the logic, but the fact that it exists, and _where_ it exists. I don't think there's a better place, and I think it's better to have that logic separated from `handleChanges`... it just still feels a tiny bit out of place.