### PR TITLE
run queries automatically on pageload

### DIFF
--- a/client/js/app/app.js
+++ b/client/js/app/app.js
@@ -54,8 +54,9 @@ function App(config) {
   } else {
     AppStateActions.update({ ready: true });
     // Run the query for this explorer if it's valid
-    var isEmailExtraction = !ExplorerUtils.isEmailExtraction(ExplorerStore.getActive());
+    var isEmailExtraction = ExplorerUtils.isEmailExtraction(ExplorerStore.getActive());
     var isValid = runValidations(explorerValidations, ExplorerStore.getActive()).isValid;
+
     if (!isEmailExtraction && isValid) {
       ExplorerActions.exec(this.client, ExplorerStore.getActive().id);
     }

--- a/test/unit/app_spec.js
+++ b/test/unit/app_spec.js
@@ -1,11 +1,35 @@
 var assert = require('chai').assert;
 var expect = require('chai').expect;
 var App = require('../../client/js/app/app.js');
+var QueryStringUtils =  require('../../client/js/app/utils/QueryStringUtils.js');
 var React = require('react/addons');
 var TestUtils = React.addons.TestUtils;
 var TestHelpers = require('../support/TestHelpers.js');
 var sinon = require('sinon');
 
 describe('app', function() {
-  
+  it('runs a query if the querystring has query attrs in it', function () {
+    var queryAttributesStub = sinon.stub(QueryStringUtils, 'getQueryAttributes').returns({
+      query: {
+        event_collection: 'pageview',
+        analysis_type: 'count',
+        time: {
+          relativity: 'this',
+          amount: 14,
+          sub_timeframe: 'days' 
+        }
+      }
+    }); 
+    var xhrOpenStub = sinon.stub(XMLHttpRequest.prototype, 'open');
+    var xhrSendStub = sinon.stub(XMLHttpRequest.prototype, 'send');
+    var client = TestHelpers.createClient();
+
+    App({client: client, targetId: 'explorer'});
+
+    assert.isTrue(queryAttributesStub.calledOnce);
+
+    QueryStringUtils.getQueryAttributes.restore();
+    xhrOpenStub.restore();
+    xhrSendStub.restore();
+  });   
 });


### PR DESCRIPTION
closes #52 

Looks like we had a mistaken `!` before `isEmailExtraction`, which was causing trouble. I removed that, and we're good to go.

I also set a sort of foundation for testing `App`.