### PR TITLE
Funnels UI:  Funnel visualization support

### DIFF
--- a/client/js/app/actions/ExplorerActions.js
+++ b/client/js/app/actions/ExplorerActions.js
@@ -211,11 +211,11 @@ var ExplorerActions = {
     NoticeActions.clearAll();
     
     var updates = _.cloneDeep(explorer);
-    updates.result = response.result;
+    updates.response = response;
     updates.loading = false;
 
-    if (!ExplorerUtils.resultSupportsChartType(response.result, explorer.metadata.visualization.chart_type, explorer.query.analysis_type)) {
-      updates.metadata.visualization.chart_type = ExplorerUtils.getChartTypeOptions(response.result, explorer.query.analysis_type)[0];
+    if (!ExplorerUtils.responseSupportsChartType(response, explorer.metadata.visualization.chart_type, explorer.query.analysis_type)) {
+      updates.metadata.visualization.chart_type = ExplorerUtils.getChartTypeOptions(response, explorer.query.analysis_type)[0];
     }
     ExplorerActions.update(explorer.id, updates);
   },

--- a/client/js/app/components/explorer/visualization/chart.js
+++ b/client/js/app/components/explorer/visualization/chart.js
@@ -16,7 +16,7 @@ var Chart = React.createClass({
 	// ***********************
 
 	buildVizContent: function() {
-	  if (!this.props.model.result && this.props.model.result !== 0) {
+	  if (!this.props.model.response) {
 	  	return (
 	  	  <div ref="notice" className="big-notice">
 	  	    <div className="alert alert-info">
@@ -62,7 +62,7 @@ var Chart = React.createClass({
 
 	  if (ExplorerUtils.isJSONViz(this.props.model)) {
 	  	var content = FormatUtils.prettyPrintJSON({
-	  		result: this.props.model.result
+	  		result: this.props.model.response.result
 	  	});
 	  	chartContent = (
 	  		<textarea ref='jsonViz' className="json-view" value={content} readOnly />

--- a/client/js/app/components/explorer/visualization/data_table.js
+++ b/client/js/app/components/explorer/visualization/data_table.js
@@ -31,7 +31,7 @@ var DataTable = React.createClass({
   render: function() {
     var dataset, headerRows, tableRows;
 
-    this.props.dataviz.data({ result: this.props.model.result });
+    this.props.dataviz.data(this.props.model.response);
     dataset = this.props.dataviz.dataset;
 
     // TODO: Fix unit tests to handle proper instantiation

--- a/client/js/app/components/explorer/visualization/index.js
+++ b/client/js/app/components/explorer/visualization/index.js
@@ -33,7 +33,7 @@ var Visualization = React.createClass({
   },
 
   formatChartTypes: function() {
-    return _.map(ExplorerUtils.getChartTypeOptions(this.props.model.result, this.props.model.query.analysis_type), function(type) {
+    return _.map(ExplorerUtils.getChartTypeOptions(this.props.model.response, this.props.model.query.analysis_type), function(type) {
       return {
         name: (type !== 'JSON') ? FormatUtils.toTitleCase(type).replace('chart', '') : type,
         value: type
@@ -55,7 +55,7 @@ var Visualization = React.createClass({
 
     var chartDetailBarClasses = classNames({
       'chart-detail-bar': true,
-      'chart-detail-active': this.props.model.result !== null && !this.props.model.loading
+      'chart-detail-active': this.props.model.response !== null && !this.props.model.loading
     });
 
 

--- a/client/js/app/components/explorer/visualization/keen_viz.js
+++ b/client/js/app/components/explorer/visualization/keen_viz.js
@@ -15,7 +15,7 @@ var KeenViz = React.createClass({
 
 	showVisualization: function() {
 		this.props.dataviz.destroy(); // Remove the old one first.
-  	this.props.dataviz.data({ result: this.props.model.result })
+  	this.props.dataviz.data(this.props.model.response)
   		.title('') // No title - not necessary for Explorer
 	    .chartType(this.props.model.metadata.visualization.chart_type)
     	.el(this.refs['keen-viz'].getDOMNode())

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -26,7 +26,7 @@ function _defaultAttrs() {
     query_name: null,
     active: false,
     saving: false,
-    result: null,
+    response: null,
     loading: false,
     isValid: true,
     errors: [],
@@ -312,7 +312,7 @@ function _setActive(id) {
 function _revertActiveChanges() {
   var active = _.find(_explorers, { active: true });
   var original = _explorers[active.id].originalModel;
-  _explorers[active.id] = _.assign({}, _.cloneDeep(original), { originalModel: original, result: active.result });
+  _explorers[active.id] = _.assign({}, _.cloneDeep(original), { originalModel: original, response: active.response });
   return active.id;
 }
 

--- a/client/js/app/utils/ExplorerUtils.js
+++ b/client/js/app/utils/ExplorerUtils.js
@@ -203,12 +203,12 @@ module.exports = {
     return params;
   },
 
-  getChartTypeOptions: function(result, analysisType) {
+  getChartTypeOptions: function(response, analysisType) {
     var chartTypes = [];
 
-    if (result) {
+    if (response) {
       var dataviz = new Keen.Dataviz();
-      dataviz.data({ result: result });
+      dataviz.data(response);
       var dataType = dataviz.dataType();
 
       if (dataType && Keen.Dataviz.dataTypeMap[dataType]) {
@@ -219,7 +219,7 @@ module.exports = {
         if (!_.contains(chartTypes, 'json')) {
           chartTypes.push('JSON');
         }
-      } else if (result && _.contains(['extraction', 'select_unique'], analysisType)) {
+      } else if (response && _.contains(['extraction', 'select_unique'], analysisType)) {
         chartTypes = ['JSON', 'table'];
       }
     }
@@ -227,8 +227,8 @@ module.exports = {
     return chartTypes;
   },
 
-  resultSupportsChartType: function(result, chartType, analysisType) {
-    return _.contains(module.exports.getChartTypeOptions(result, analysisType), chartType);
+  responseSupportsChartType: function(response, chartType, analysisType) {
+    return _.contains(module.exports.getChartTypeOptions(response, analysisType), chartType);
   },
 
   encodeAttribute: function(attr) {
@@ -277,7 +277,7 @@ module.exports = {
   },
 
   resultCanBeVisualized: function(explorer) {
-    return (explorer.result || _.isNumber(explorer.result) || (_.isArray(explorer.result) && explorer.result.length));
+    return (explorer.response && explorer.response.result && (_.isNumber(explorer.response.result) || (_.isArray(explorer.response.result) && explorer.response.result.length)));
   },
 
   isJSONViz: function(explorer) {

--- a/test/support/TestHelpers.js
+++ b/test/support/TestHelpers.js
@@ -32,7 +32,7 @@ module.exports = {
     return {
       id: 'some_id',
       active: false,
-      result: null,
+      response: null,
       loading: false,
       saving: false,
       isValid: true,

--- a/test/unit/actions/ExplorerActionsSpec.js
+++ b/test/unit/actions/ExplorerActionsSpec.js
@@ -282,7 +282,7 @@ describe('actions/ExplorerActions', function() {
     it('should call the dispatcher to update with the right arguments', function () {
       var expectedUpdates = _.cloneDeep(this.explorer);
       expectedUpdates.loading = false;
-      expectedUpdates.result = 100;
+      expectedUpdates.response = this.response;
       expectedUpdates.metadata.visualization.chart_type = 'metric';
       
       ExplorerActions.execSuccess(this.explorer, this.response);

--- a/test/unit/actions/ExplorerActionsSpec.js
+++ b/test/unit/actions/ExplorerActionsSpec.js
@@ -272,11 +272,11 @@ describe('actions/ExplorerActions', function() {
       };
       this.response = { result: 100 };
       sinon.stub(ExplorerUtils, 'getChartTypeOptions').returns(['metric']);
-      sinon.stub(ExplorerUtils, 'resultSupportsChartType').returns(false);
+      sinon.stub(ExplorerUtils, 'responseSupportsChartType').returns(false);
     });
     afterEach(function () {
       ExplorerUtils.getChartTypeOptions.restore();
-      ExplorerUtils.resultSupportsChartType.restore();
+      ExplorerUtils.responseSupportsChartType.restore();
     });
 
     it('should call the dispatcher to update with the right arguments', function () {

--- a/test/unit/components/explorer/visualization/chart_spec.js
+++ b/test/unit/components/explorer/visualization/chart_spec.js
@@ -27,7 +27,7 @@ describe('components/explorer/visualization/chart', function() {
     it('shows the correct message about email extractions ', function () {
       this.model.query.analysis_type = 'extraction';
       this.model.query.email = 'someone@keen.io';
-      this.model.result = { success: true };
+      this.model.response = { result: 10, success: true };
       this.component = TestUtils.renderIntoDocument(<Chart model={this.model} dataviz={this.dataviz} />);
       var message = "Email extractions don't have visualizations.";
       assert.equal(this.component.refs.notice.getDOMNode().textContent, message);

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -23,7 +23,7 @@ describe('stores/ExplorerStore', function() {
       ExplorerActions.create();
       var defaults = {
         active: false,
-        result: null,
+        response: null,
         loading: false,
         saving: false,
         isValid: true,
@@ -723,7 +723,7 @@ describe('stores/ExplorerStore', function() {
         var expectedModel = {
           id: 'ABC-SOME-ID',
           active: true,
-          result: null,
+          response: null,
           loading: false,
           saving: false,
           isValid: true,


### PR DESCRIPTION
This fixes the issue where we couldn't visualize funnel query responses. Keen.js requires the entire response in order to properly auto-visualize a Funnel query. Rather than just storing the result of a query in the model (ExplorerStore models), we're instead storing the entire response.