### PR TITLE
Set a default visualization for saved queries without a chart type

### DIFF
--- a/client/js/app/components/explorer/visualization/index.js
+++ b/client/js/app/components/explorer/visualization/index.js
@@ -41,6 +41,16 @@ var Visualization = React.createClass({
     });
   },
 
+  chartType: function() {
+    if (this.props.model.metadata.visualization &&
+        this.props.model.metadata.visualization.chart_type) {
+      return this.props.model.metadata.visualization.chart_type;
+    }
+    else {
+      return _.first(ExplorerUtils.getChartTypeOptions(this.props.model.response, this.props.model.query.analysis_type))
+    }
+  },
+
   componentWillMount: function() {
     this.dataviz = new Keen.Dataviz();
   },
@@ -81,7 +91,6 @@ var Visualization = React.createClass({
       );
     }
 
-
     return (
       <div className="visualization">
         <Notice notice={this.props.notice} closeCallback={this.noticeClosed} />
@@ -99,7 +108,7 @@ var Visualization = React.createClass({
                           classes="chart-type"
                           options={this.formatChartTypes()}
                           handleSelection={this.changeChartType}
-                          selectedOption={this.props.model.metadata.visualization.chart_type}
+                          selectedOption={this.chartType()}
                           emptyOption={false}
                           disabled={this.props.model.loading} />
                 </div>

--- a/test/unit/components/explorer/visualization/index_spec.js
+++ b/test/unit/components/explorer/visualization/index_spec.js
@@ -2,7 +2,6 @@
 var assert = require('chai').assert;
 var _ = require('lodash');
 var sinon = require('sinon');
-var Select = require('../../../../../client/js/app/components/common/select.js');
 var Visualization = require('../../../../../client/js/app/components/explorer/visualization/index.js');
 var Chart = require('../../../../../client/js/app/components/explorer/visualization/chart.js');
 var React = require('react/addons');
@@ -95,6 +94,20 @@ describe('components/explorer/visualization/index', function() {
       assert.isTrue(this.component.refs['chart-type'].refs.select.getDOMNode().disabled);
     });
 
+  });
+
+  describe('default chart type', function() {
+    it('renders a default chart type if there is no metadata.visualization object', function() {
+      this.chartOptionsStub.returns([
+          'metric',
+          'JSON'
+      ]);
+
+      this.component.forceUpdate();
+      var selectField = this.component.refs['chart-type'].refs.select;
+
+      assert.equal(selectField.props.value, 'metric');
+    });
   });
 
 });


### PR DESCRIPTION
#### What's this PR do?

Sets a default chart type if a saved query doesn't have a `chart_type` set. The default chart type is the first item returned from `ExplorerUtils.getChartTypeOptions`.

#### Where should the reviewer start?

* `client/js/app/components/explorer/visualization/index.js#43`

#### How should this be manually tested?

- [x] Run tests for `visualization/index.js`
- [x] in `demo/index.html`, set the properties in keen client for project id `5011efa95f546f2ce2000000`, like so:
```js
      client = new Keen({
        projectId: "5011efa95f546f2ce2000000",
        readKey: "ef717eaec4aeb8e8b8b18891ffaa1eafed8c14cac1f7cb90030eaa7ed79ed2d540ee267547267c73f4c6e7ff9bcb8f7dec4df9500499a70737777d71971a20e6e3cd6532b44a44c5d269811178c2308867fd5082d44e51c05496b0099c4a06649207b8db43fe0458cf3cc059f5ecaadc",
        masterKey: "project master key here",
        protocol: "https",
        host: "api.keen.io/3.0",
        requestType: "xhr"
      });
```
- [x] run `gulp`
- [x] go to `http://localhost:8081/?saved_query=paying-customers-grouped-by-first-internal-referrer`
- [x] Observe that nothing breaks and a chart is rendered