### PR TITLE
Add 'repository' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
       "reactify"
     ]
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:keen/explorer.git"
+  },
   "devDependencies": {
     "browserify": "11.2.0",
     "browserify-shim": "~3.8.0",


### PR DESCRIPTION
## What does this PR do? How does it affect users?

This removes the warning "keen-explorer 2.0.0: No repository field"

## How should this be tested?

Run `npm install`. The warning message should not be at the end of the output.