### PR TITLE
Removed old copy

### DIFF
--- a/client/js/app/components/explorer/query_actions.js
+++ b/client/js/app/components/explorer/query_actions.js
@@ -59,7 +59,7 @@ var QueryActions = React.createClass({
         actionsSupported = false;
         saveMsg = (
           <p className="no-margin margin-top-tiny">
-            <small>The Keen IO API currently does not support saving email extraction or funnel queries.</small>
+            <small>The Keen IO API currently does not support saving email extraction.</small>
           </p>
         );
       }


### PR DESCRIPTION
## What does this PR do? How does it affect users?
Corrects some copy in the Explorer that shows when doing an extraction. Keen IO API now supports saved queries. 

## How should this be tested?
Visually check that the copy is now accurate. Try to do an extraction with the "Bulk CSV extraction by email" radio button to see where it appears in the Explorer. 

## Related tickets?
Couldn't find any