### PR TITLE
Avoid overwriting the React global variable

### DIFF
--- a/client/js/app/app.js
+++ b/client/js/app/app.js
@@ -96,7 +96,6 @@ App.prototype.render = function() {
   }), this.targetNode);
 };
 
-window.React = React;
 window.Keen = window.Keen || {};
 window.Keen.Explorer = window.Keen.Explorer || {};
 window.Keen.Explorer.Persistence = Persistence;


### PR DESCRIPTION
I don't see a need to expose the React when loading the explorer.

I assume that this was done initially to make it possible to use the React DevTools, but the integration between React and its DevTools was changed in React 0.12 to avoid requiring to have React as a global (instead, the DevTools are exposing a global variable)