### PR TITLE
Ensure steps appear in correct order on funnel visualizations

### DIFF
--- a/client/js/app/components/explorer/visualization/keen_viz.js
+++ b/client/js/app/components/explorer/visualization/keen_viz.js
@@ -24,7 +24,7 @@ var KeenViz = React.createClass({
       .title(null)
       .type(this.props.model.metadata.visualization.chart_type);
 
-    if (!this.props.model.query.analysis_type === "funnel") {
+    if (this.props.model.query.analysis_type !== "funnel") {
       this.props.dataviz.sortGroups('desc')
     }
 

--- a/client/js/app/components/explorer/visualization/keen_viz.js
+++ b/client/js/app/components/explorer/visualization/keen_viz.js
@@ -22,8 +22,11 @@ var KeenViz = React.createClass({
       .el(this.refs['keen-viz'])
       .height(300)
       .title(null)
-      .sortGroups('desc')
       .type(this.props.model.metadata.visualization.chart_type);
+
+    if (!this.props.model.query.analysis_type === "funnel") {
+      this.props.dataviz.sortGroups('desc')
+    }
 
     this.props.dataviz.render();
 


### PR DESCRIPTION
## What does this PR do?

Resolves issue causing funnel steps to appear out of order in some visualizations. 

## How can I test this?

Get the Explorer running locally and try running several funnel analyses. Ensure that the order of the steps in your charts matches the order of the steps in your query.