### PR TITLE
Fix Issue #167

### DIFF
--- a/client/js/app/app.js
+++ b/client/js/app/app.js
@@ -35,7 +35,7 @@ App.prototype.client = function(obj) {
   if (!arguments.length) return this.config.client;
   this.config.client = new KeenAnalysis(obj);
   this.config.client.resources({
-    'events': '{protocol}://{host}/projects/{projectId}/events'
+    'events': '{protocol}://{host}/3.0/projects/{projectId}/events'
   });
   ProjectActions.create({ client: this.config.client });
   ProjectActions.fetchProjectCollections(this.config.client);

--- a/client/js/app/utils/ExplorerUtils.js
+++ b/client/js/app/utils/ExplorerUtils.js
@@ -275,7 +275,7 @@ module.exports = {
   getSdkExample: function(explorer, client) {
 
     var defaultKeenJsOpts = {
-          host: 'api.keen.io/3.0',
+          host: 'api.keen.io',
           protocol: 'https',
           requestType: 'jsonp'
         },

--- a/client/js/app/utils/ExplorerUtils.js
+++ b/client/js/app/utils/ExplorerUtils.js
@@ -274,7 +274,7 @@ module.exports = {
 
   getSdkExample: function(explorer, client) {
 
-    var defaultKeenJsOpts = {
+    var defaultKeenAnalysisOpts = {
           host: 'api.keen.io',
           protocol: 'https',
           requestType: 'jsonp'
@@ -306,7 +306,7 @@ module.exports = {
     }
 
     dynamicConstructorValues = mapSkip(dynamicConstructorNames, function(name) {
-      if (client.config[name] == defaultKeenJsOpts[name]) {
+      if (client.config[name] == defaultKeenAnalysisOpts[name]) {
         return SKIP
       }
       return '  ' + name + ': ' + s(client.config[name])

--- a/test/support/TestHelpers.js
+++ b/test/support/TestHelpers.js
@@ -17,7 +17,7 @@ module.exports = {
     return {
       projectId: 'projectId',
       protocol: 'https',
-      host: 'api.keen.io/3.0',
+      host: 'api.keen.io',
       masterKey: 'masterKey'
     };
   },


### PR DESCRIPTION
The goal of this PR is to remove the `host` property from the embeddable code sample without making any changes to the client. This is an update to https://github.com/keen/explorer/pull/170.

