### PR TITLE
Fix issue #150

### DIFF
--- a/client/js/app/utils/ExplorerUtils.js
+++ b/client/js/app/utils/ExplorerUtils.js
@@ -297,7 +297,7 @@ module.exports = {
         break;
 
       default:
-        paramNames = ['event_collection', 'filters', 'group_by', 'interval', 'target_property', 'timeframe', 'timezone'];
+        paramNames = ['event_collection', 'filters', 'group_by', 'interval', 'target_property', 'percentile', 'timeframe', 'timezone'];
         break;
     }
 


### PR DESCRIPTION
Resolves https://github.com/keen/explorer/issues/150. The embeddable code sample for percentile queries now includes the percentile property and value. 

**Note:** The percentile value is currently being saved and executed as a string (https://github.com/keen/explorer/issues/168) instead of a number. Planning to fix that issue and roll the changes out together to prevent additional confusion for folks copy/pasting the code sample.

