### PR TITLE
Feature request #138

### DIFF
--- a/client/js/app/components/common/filter.js
+++ b/client/js/app/components/common/filter.js
@@ -21,15 +21,21 @@ var Filter = React.createClass({
     this.props.handleChange(this.props.index, name, value);
   },
 
+
   handleChangeWithEvent: function(e) {
     this.props.handleChange(this.props.index, e.target.name, e.target.value);
+  },
+
+  handleKeyPress: function(key) {
+    this.props.handleKeyPress(key);
   },
 
   buildValueFormGroup: function() {
     return (
       <FilterValueFields filter={this.props.filter}
                          filterOperators={this.props.filterOperators}
-                         handleChange={this.handleChange} />
+                         handleChange={this.handleChange} 
+                         handleKeyPress={this.handleKeyPress} />
     );
   },
 

--- a/client/js/app/components/common/filter_manager.js
+++ b/client/js/app/components/common/filter_manager.js
@@ -25,6 +25,10 @@ var FilterManager = React.createClass({
     this.refs.modal.open();
   },
 
+  close: function() {
+    this.refs.modal.close();
+  },
+
   addFilter: function(e) {
     e.preventDefault();
     this.props.addFilter();
@@ -49,6 +53,12 @@ var FilterManager = React.createClass({
     this.props.handleChange(index, updates);
   },
 
+  handleKeyPress: function(key) {
+    if (key === 'Enter') {
+      this.close();
+    }
+  },
+
   buildFilterNodes: function() {
     var filterNodes = this.props.filters.map(function(filter, index) {
       return(
@@ -59,6 +69,7 @@ var FilterManager = React.createClass({
                 eventCollection={this.props.eventCollection}
                 propertyNames={this.props.propertyNames}
                 handleChange={this.handleChange}
+                handleKeyPress={this.handleKeyPress}
                 removeFilter={this.removeFilter}
                 filterOperators={ProjectUtils.getConstant('FILTER_OPERATORS')} />
       );

--- a/client/js/app/components/common/filter_value_fields.js
+++ b/client/js/app/components/common/filter_value_fields.js
@@ -49,6 +49,10 @@ var FilterValueFields = React.createClass({
     this.props.handleChange(event.target.name, event.target.value);
   },
 
+  handleKeyPress: function(event) {
+    this.props.handleKeyPress(event.key);
+  },
+
   getCoercionOptions: function() {
     var operator = this.props.filter.operator;
     return operator ? _.find(this.props.filterOperators, { value: operator }).canBeCoeredTo : [];
@@ -123,6 +127,7 @@ var FilterValueFields = React.createClass({
                value={this.state.property_value}
                onChange={this.setValueState}
                onBlur={this.handleChangeWithEvent}
+               onKeyPress={this.handleKeyPress}
                placeholder={this.getInputPlaceholder()}
                readOnly={this.props.filter.coercion_type === 'Null'}/>
       );

--- a/dist/keen-explorer.css
+++ b/dist/keen-explorer.css
@@ -811,7 +811,6 @@
 }
 .keen-dataviz .keen-spinner-indicator {
   border-radius: 100%;
-  border: 3px solid #000000;
   border: 3px solid rgba(0, 0, 0, 0.1);
   border-top-color: rgba(0, 0, 0, 0.45);
   box-sizing: border-box;
@@ -858,7 +857,6 @@
   top: 0;
 }
 .keen-c3-legend-label-overlay {
-  background: #ffffff;
   background: rgba(255, 255, 255, 0.9);
   box-shadow: 0 1px 1px rgba(26, 26, 26, 0.1);
   font-family: 'Gotham Rounded SSm A', 'Gotham Rounded SSm B', 'Helvetica Neue', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
## What does this PR do? How does it affect users?

Added feature requested in #138.  This allows the user while filtering to hit enter from a text field, apply the filter, and close the modal.
## How should this be tested?

I checked the test coverage for the modal and there is already a close test case.  This addition only utilizes functionality already covered.  There is no parameters passed so test case does not need to be expanded.

Currently this feature is only applied to text inputs as specified in the ticket.
## Related tickets?
#138
