### PR TITLE
Use latest keen-dataviz.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "flux": "^2.0.3",
     "json-stable-stringify": "1.0.0",
     "keen-analysis": "^1.1.0",
-    "keen-dataviz": "^1.0.3",
+    "keen-dataviz": "^1.0.4",
     "keymirror": "~0.1.0",
     "lodash": "4.0.0",
     "moment": "^2.7.0",


### PR DESCRIPTION
## What does this PR do?
It updates explorer to use the latest version of keen-dataviz.js, which is `v1.0.4`.