### PR TITLE
Add percentile value validation

### DIFF
--- a/client/js/app/validations/ExplorerValidations.js
+++ b/client/js/app/validations/ExplorerValidations.js
@@ -55,7 +55,7 @@ module.exports = {
     },
     
     validate: function(model) {
-      return typeof model.query.percentile ==='number';
+      return typeof model.query.percentile === 'number';
     }
 
   },

--- a/client/js/app/validations/ExplorerValidations.js
+++ b/client/js/app/validations/ExplorerValidations.js
@@ -46,6 +46,20 @@ module.exports = {
 
   },
 
+  percentile_value: {
+    
+    msg: 'Choose a Percentile Value.',
+
+    shouldRun: function(model) {
+      return model.query.analysis_type === 'percentile';
+    },
+    
+    validate: function(model) {
+      return typeof model.query.percentile ==='number';
+    }
+
+  },
+
   filters: {
 
     shouldRun: isNotFunnel,

--- a/client/js/app/validations/ExplorerValidations.js
+++ b/client/js/app/validations/ExplorerValidations.js
@@ -55,7 +55,7 @@ module.exports = {
     },
     
     validate: function(model) {
-      return typeof model.query.percentile === 'number';
+      return model.query.percentile !== null && model.query.percentile !== '' && typeof model.query.percentile === 'number';
     }
 
   },

--- a/dist/keen-explorer.css
+++ b/dist/keen-explorer.css
@@ -533,7 +533,6 @@
 /*-- Chart --*/
 .c3 svg {
   font: 10px sans-serif;
-  -webkit-tap-highlight-color: transparent;
 }
 .c3 path,
 .c3 line {
@@ -611,11 +610,11 @@
 /*-- Region --*/
 .c3-region {
   fill: steelblue;
-  fill-opacity: .1;
+  fill-opacity: 0.1;
 }
 /*-- Brush --*/
 .c3-brush .extent {
-  fill-opacity: .1;
+  fill-opacity: 0.1;
 }
 /*-- Select - Drag --*/
 /*-- Legend --*/
@@ -630,10 +629,6 @@
   fill: white;
   stroke: lightgray;
   stroke-width: 1;
-}
-/*-- Title --*/
-.c3-title {
-  font: 14px sans-serif;
 }
 /*-- Tooltip --*/
 .c3-tooltip-container {
@@ -816,6 +811,7 @@
 }
 .keen-dataviz .keen-spinner-indicator {
   border-radius: 100%;
+  border: 3px solid #000000;
   border: 3px solid rgba(0, 0, 0, 0.1);
   border-top-color: rgba(0, 0, 0, 0.45);
   box-sizing: border-box;
@@ -862,6 +858,7 @@
   top: 0;
 }
 .keen-c3-legend-label-overlay {
+  background: #ffffff;
   background: rgba(255, 255, 255, 0.9);
   box-shadow: 0 1px 1px rgba(26, 26, 26, 0.1);
   font-family: 'Gotham Rounded SSm A', 'Gotham Rounded SSm B', 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/test/unit/validations/ExplorerValidationsSpec.js
+++ b/test/unit/validations/ExplorerValidationsSpec.js
@@ -101,6 +101,21 @@ describe('validations/ExplorerValidations', function() {
       });
     });
 
+    describe('percentile_value', function () {
+      it('has an error message', function () {
+        var errorMessage = ExplorerValidations.percentile_value.msg;
+        assert.equal(errorMessage, 'Choose a Percentile Value.');
+      });
+
+      it('returns true when a percentile value is present', function () {
+        assert.isTrue(ExplorerValidations.percentile_value.validate({ query: { percentile: 50 } }));
+      });
+
+      it('returns false when there is no percentile value', function () {
+        assert.isFalse(ExplorerValidations.percentile_value.validate({ query: { percentile: null } }));
+      });
+    });
+
     describe('filters', function () {
       describe('when query has invalid filters', function () {
         it('has an error message', function () {


### PR DESCRIPTION
### What does this PR do?

It's currently possible for a user to run a percentile query without a percentile value (a required field). This results in an error and the query appearing to load indefinitely. This PR addresses that issue by adding validation to notify users when the percentile value is missing.

### How can I test this?

- Run a percentile query with no percentile value and confirm that an error is displayed in the UI. 
- Run a percentile query with a percentile value and confirm that it executes as expected.
- Confirm all tests pass.