### PR TITLE
Implemented the clone function:

### DIFF
--- a/client/js/app/actions/ExplorerActions.js
+++ b/client/js/app/actions/ExplorerActions.js
@@ -26,6 +26,18 @@ var ExplorerActions = {
       models: models
     });
   },
+  
+  clone: function(sourceId) {
+	AppDispatcher.dispatch({
+	  actionType: ExplorerConstants.EXPLORER_CLONE,
+	  id: sourceId
+	});
+	NoticeActions.create({
+      text: "Query cloned! Set a name for this cloned query and save it",
+      type: 'success',
+      icon: 'check'
+    });
+  },
 
   update: function(id, updates) {
     var updated_query, project = ProjectStore.getProject();

--- a/client/js/app/components/explorer/index.js
+++ b/client/js/app/components/explorer/index.js
@@ -82,6 +82,14 @@ var Explorer = React.createClass({
     event.preventDefault();
     ExplorerActions.save(this.props.persistence, this.state.activeExplorer.id);
   },
+  
+  cloneQueryClick: function(event) {
+	event.preventDefault();
+	ExplorerActions.clone(this.state.activeExplorer.id);
+    var newExplorer = ExplorerStore.getLast();
+    ExplorerActions.setActive(newExplorer.id);
+    this.setState({ activeQueryPane: 'build' });
+  },
 
   createNewQuery: function(event) {
     event.preventDefault();
@@ -308,6 +316,7 @@ var Explorer = React.createClass({
                           handleQuerySubmit={this.handleQuerySubmit}
                           saveQueryClick={this.saveQueryClick}
                           removeClick={this.removeSavedQueryClicked}
+                          cloneQueryClick={this.cloneQueryClick}
                           persistence={this.props.persistence}
                           codeSampleHidden={this.state.appState.codeSampleHidden}
                           toggleCodeSample={this.toggleCodeSample} />

--- a/client/js/app/components/explorer/query_actions.js
+++ b/client/js/app/components/explorer/query_actions.js
@@ -35,6 +35,7 @@ var QueryActions = React.createClass({
   render: function() {
     var saveMsg,
         saveBtn,
+        cloneBtn,
         deleteBtn,
         actionsSupported = true,
         runButtonClasses = classNames({
@@ -69,6 +70,13 @@ var QueryActions = React.createClass({
           Delete
         </button>
       );
+      if (isPersisted) {
+        cloneBtn = (
+          <button type="button" className="btn btn-primary" onClick={actionsSupported ? this.props.cloneQueryClick : function(){}} role="clone-query" disabled={this.props.model.loading || !actionsSupported}>
+            Clone
+          </button>
+        );
+      }
     }
 
     return (
@@ -82,6 +90,7 @@ var QueryActions = React.createClass({
             </div>
             <div className="manage-group pull-left">
               {saveBtn}
+              {cloneBtn}
               {deleteBtn}
             </div>
           </div>

--- a/client/js/app/constants/ExplorerConstants.js
+++ b/client/js/app/constants/ExplorerConstants.js
@@ -3,6 +3,7 @@ var keyMirror = require('keymirror');
 module.exports = keyMirror({
   EXPLORER_CREATE: null,
   EXPLORER_CREATE_BATCH: null,
+  EXPLORER_CLONE: null,
   EXPLORER_UPDATE: null,
   EXPLORER_REMOVE: null,
   EXPLORER_SET_ACTIVE: null,

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -100,6 +100,17 @@ function _defaultStep() {
   }
 }
 
+/**
+ * Clone the query attributes to a new object.
+ * @param {Object} source  Source object from get the data to be copied.
+ * @returns {Object} Copy of the query attributes of th source object
+ */
+function _cloneAttrs(source) {
+	return {
+	    query: source.query
+	};
+}
+
 function _validate(id) {
   RunValidations(ExplorerValidations, _explorers[id]);
 }
@@ -534,6 +545,12 @@ ExplorerStore.dispatchToken = AppDispatcher.register(function(action) {
       action.models.forEach(function(model) {
         _explorers[model.id] ? _update(model.id, model) : _create(model);        
       });
+      finishAction();
+      break;
+      
+    case ExplorerConstants.EXPLORER_CLONE:
+      var source = ExplorerStore.get(action.id);
+      _create(_cloneAttrs(source));
       finishAction();
       break;
 

--- a/test/unit/actions/ExplorerActionsSpec.js
+++ b/test/unit/actions/ExplorerActionsSpec.js
@@ -468,5 +468,15 @@ describe('actions/ExplorerActions', function() {
 
       });
     });
+    
+    describe('clone a saved query', function () {
+        it('should dispatch an EXPLORER_CLONE event', function () {
+          ExplorerActions.clone('ABC');
+          assert.isTrue(this.dispatchStub.calledWith({
+            actionType: 'EXPLORER_CLONE',
+            id: 'ABC'
+          }));
+        });
+    });
   });
 });

--- a/test/unit/components/explorer/index_spec.js
+++ b/test/unit/components/explorer/index_spec.js
@@ -262,6 +262,47 @@ describe('components/explorer/index', function() {
       });
 
     });
+      
+    describe('cloneQueryClick', function () {
+      beforeEach(function() {
+        ExplorerStore.clearAll();
+        ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'abc', metadata: { display_name: 'abc' } }));
+        ExplorerActions.setActive('abc');
+        ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'def', metadata: { display_name: 'def' } }));
+        ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'ghi', metadata: { display_name: 'ghi' } }));
+
+        var props = _.assign({}, this.component.props, { persistence: {} });
+        this.component = TestHelpers.renderComponent(Explorer, props);
+      });
+      it('should add a new explorer in the store', function () {
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        assert.strictEqual(_.keys(ExplorerStore.getAll()).length, 4);
+      });
+      it('should set the newly created explorer as active', function () {
+        var stub = sinon.stub(ExplorerActions, 'setActive');
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        var keys = _.keys(ExplorerStore.getAll());
+        var lastExplorer = ExplorerStore.getAll()[keys[keys.length-1]];
+        assert.isTrue(stub.calledWith(lastExplorer.id));
+        ExplorerActions.setActive.restore();
+      });
+      it('should change the text on the query builder tab to "Create a new query"', function () {
+        assert.strictEqual(this.component.refs['query-pane-tabs'].refs['build-tab'].textContent, 'Edit query');
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        this.component._onChange();
+        assert.strictEqual(this.component.refs['query-pane-tabs'].refs['build-tab'].textContent, 'Create a new query');
+      });
+      it('should update component state to show the build tab', function () {
+        this.component.setState({ activeQueryPane: 'browse' });
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        assert.strictEqual(this.component.state.activeQueryPane, 'build');
+      });
+      it('should call clone method passing current or active explorer', function() {
+    	  var cloneStub = sinon.stub(ExplorerActions, 'clone');
+    	  this.component.cloneQueryClick(TestHelpers.fakeEvent());
+    	  assert.isTrue(cloneStub.calledWith('abc'));
+      });
+    });
 
     describe('createNewQuery', function () {
       beforeEach(function() {

--- a/test/unit/components/explorer/query_actions_spec.js
+++ b/test/unit/components/explorer/query_actions_spec.js
@@ -52,6 +52,9 @@ describe('components/explorer/query_actions', function() {
           it('does not show the delete button if persistence is null', function () {
             assert.lengthOf($R(this.component).find('[role="delete-query"]').components, 0);
           });
+          it('does not show the clone button if persistence is null', function () {
+            assert.lengthOf($R(this.component).find('[role="clone-query"]').components, 0);
+          });
         });
         describe('with persistence', function () {
           it('does show the save button', function () {
@@ -61,6 +64,10 @@ describe('components/explorer/query_actions', function() {
           it('does show the delete button', function () {
             this.component = this.renderComponent({ persistence: {} });
             assert.lengthOf($R(this.component).find('[role="delete-query"]').components, 1);
+          });
+          it('does show the clone button', function () {
+            this.component = this.renderComponent({ persistence: {} });
+            assert.lengthOf($R(this.component).find('[role="clone-query"]').components, 1);
           });
           describe('if the query is an email extraction', function () {
             it('the save button is disabled', function () {

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -121,6 +121,25 @@ describe('stores/ExplorerStore', function() {
       assert.typeOf(ExplorerStore.get('abc123').query.percentile, 'number');
     });
   });
+  
+  describe('clone', function () {
+	it('should clone only query data', function() {
+	  ExplorerActions.create({
+	    id: 'abc123',
+	    query: {
+		  event_collection: 'signups',
+	      analysis_type: 'count'
+		}
+	  });
+	  var source = ExplorerStore.get('abc123');
+	  ExplorerActions.clone(source.id);
+	  var keys = Object.keys(ExplorerStore.getAll());
+	  assert.lengthOf(Object.keys(ExplorerStore.getAll()), 2);
+	  assert.isTrue(ExplorerStore.getAll()[keys[keys.length - 1]].id != source.id);
+      assert.deepPropertyVal(ExplorerStore.getAll()[keys[keys.length - 1]], 'query.event_collection', 'signups');
+      assert.deepPropertyVal(ExplorerStore.getAll()[keys[keys.length - 1]], 'query.analysis_type', 'count');
+	})
+  });
 
   describe('createBatch', function () {
     it('should create a model for every object in the array under the key "models"', function () {


### PR DESCRIPTION
## What does this PR do? How does it affect users?

It implements a Clone function for saved queries, the user is able to clone a saved query to later apply some changes and save the cloned query as a new query.
## How should this be tested?

Thinking in UAT this should be tested, first creating or saving a query and after that use the Clone button to make a clone of the saved query and check the cloned query can be modified before create a new one.

Also, it is important to mention tests have been created following the same guidelines I´ve seen in the code, most important files modified are ExplorerActions.js and ExplorerStore.js from my point of view but also query_actions.js and index.js in components/explorer path.

In terms of Development, I´ve tried to be as less intrusive as possible and also I made some assumptions like only the query attributes of a saved query is cloned, nothing related to id, name or other attributes not in query attribute of the explorer object. A function _cloneAttrs has been created in ExplorerStore.js just in case is needed to copy more attributes, it will be easier to only modified this funciton which should return the attributes to be merged by the _create function. Also, it could be important to mention to clone the query, first the main function in ExplorerStore.js is getting the data of the source explorer object to later copy the relevant attributes and finally call to _create function passing the copied attributes to create a new explorer object with the relevant attributes. It is also important to say that the dispatcher is used to populate a clone event has been raised from the Clone button, following the same implemented approach than create a new explorer object or query.

There are a couple of things I´m not 100% sure, one is the message shown to the end-user when Clone button is used, and the other one is the attributes copied, not sure if other attributes should be copied or only with the query object inside of a explorer object is enough.
## Related tickets?

I´ve made the decision to implement this feature because I´ve seen the ticket #151 where it was requested and I´m expecting also to use this function soon in one of the project I´m involved and I will use Keen platform to collect data.
