### PR TITLE
Toggle dataviz config component

### DIFF
--- a/client/js/app/components/explorer/index.js
+++ b/client/js/app/components/explorer/index.js
@@ -197,6 +197,13 @@ var Explorer = React.createClass({
     });
   },
 
+  toggleVizConfig: function(event) {
+    event.preventDefault();
+    AppStateActions.update({
+      vizConfigHidden: !this.state.appState.vizConfigHidden
+    });
+  },
+
   getEventPropertyNames: function(collection)  {
     return ProjectUtils.getEventCollectionPropertyNames(
       this.props.project,
@@ -300,6 +307,7 @@ var Explorer = React.createClass({
                            onNameChange={this.onNameChange}
                            appState={this.state.appState}
                            toggleCodeSample={this.toggleCodeSample}
+                           toggleVizConfig={this.toggleVizConfig}
                            onQueryNameChange={this.onQueryNameChange}
                            onDisplayNameChange={this.onDisplayNameChange} />
             {cacheToggle}
@@ -310,7 +318,9 @@ var Explorer = React.createClass({
                           removeClick={this.removeSavedQueryClicked}
                           persistence={this.props.persistence}
                           codeSampleHidden={this.state.appState.codeSampleHidden}
-                          toggleCodeSample={this.toggleCodeSample} />
+                          vizConfigHidden={this.state.appState.vizConfigHidden}
+                          toggleCodeSample={this.toggleCodeSample}
+                          toggleVizConfig={this.toggleVizConfig} />
           </div>
         </div>
         <EventBrowser ref="event-browser"

--- a/client/js/app/components/explorer/query_actions.js
+++ b/client/js/app/components/explorer/query_actions.js
@@ -33,23 +33,6 @@ var QueryActions = React.createClass({
     return this.props.model.loading ? btnStates.active : btnStates.inactive;
   },
 
-  getInitialState: function() {
-    return {
-      showVizConfig: false
-    };
-  },
-
-  toggleVizConfig: function() {
-    this.setState({
-      showVizConfig: true
-    });
-  },
-
-  onCloseClick: function() {
-    return console.log('test');
-
-  },
-
   render: function() {
     var saveMsg,
         saveBtn,
@@ -63,6 +46,10 @@ var QueryActions = React.createClass({
           'btn btn-default code-sample-toggle pull-right': true,
           'open': !this.props.codeSampleHidden
         });
+        vizConfigBtnClasses = classNames({
+          'btn btn-default viz-config-toggle pull-right': true,
+          'open': !this.props.vizConfigHidden
+        })
 
     var isEmailExtraction = ExplorerUtils.isEmailExtraction(this.props.model);
     var isPersisted = ExplorerUtils.isPersisted(this.props.model);
@@ -107,18 +94,10 @@ var QueryActions = React.createClass({
             <button className={codeSampleBtnClasses} role="toggle-code-sample" onClick={this.props.toggleCodeSample}>
               <span>&lt;/&gt; Embed</span>
             </button>
-
-            <button className="btn btn-default pull-right" role="toggle-viz-config" onClick={this.toggleVizConfig}>
+            <button className={vizConfigBtnClasses} role="toggle-viz-config" onClick={this.props.toggleVizConfig}>
               Customize
             </button>
           </div>
-
-          <div className="row"> 
-            <div className="col-md-12">
-              {this.state.showVizConfig ? <KeenVizConfig onCloseClick={this.onCloseClick} /> : null }
-            </div>
-          </div>
-
         </div>
         {saveMsg}
       </div>

--- a/client/js/app/components/explorer/query_actions.js
+++ b/client/js/app/components/explorer/query_actions.js
@@ -2,6 +2,7 @@ var React = require('react');
 var classNames = require('classnames');
 var _ = require('lodash');
 var ExplorerUtils = require('../../utils/ExplorerUtils');
+var KeenVizConfig = require('./visualization/keen_viz_config.js');
 
 var QueryActions = React.createClass({
 
@@ -30,6 +31,18 @@ var QueryActions = React.createClass({
     }
 
     return this.props.model.loading ? btnStates.active : btnStates.inactive;
+  },
+
+  getInitialState: function() {
+    return {
+      showVizConfig: false
+    };
+  },
+
+  toggleVizConfig: function() {
+    this.setState({
+      showVizConfig: true
+    });
   },
 
   render: function() {
@@ -74,7 +87,7 @@ var QueryActions = React.createClass({
     return (
       <div className="query-actions clearfix">
         <div className="row">
-          <div className="col-md-10 clearfix">
+          <div className="col-md-6 clearfix">
             <div className="run-group pull-left">
               <button type="submit" role="run-query" className={runButtonClasses} id="run-query" onClick={this.props.handleQuerySubmit}>
                 {this.runButtonText()}
@@ -85,10 +98,15 @@ var QueryActions = React.createClass({
               {deleteBtn}
             </div>
           </div>
-          <div className="col-md-2">
+          <div className="col-md-6">
             <button className={codeSampleBtnClasses} role="toggle-code-sample" onClick={this.props.toggleCodeSample}>
               <span>&lt;/&gt; Embed</span>
             </button>
+
+            <button className="btn btn-default pull-right" role="toggle-viz-config" onClick={this.toggleVizConfig}>
+              Customize
+            </button>
+            {this.state.showVizConfig ? <KeenVizConfig /> : null }
           </div>
         </div>
         {saveMsg}

--- a/client/js/app/components/explorer/query_actions.js
+++ b/client/js/app/components/explorer/query_actions.js
@@ -45,6 +45,11 @@ var QueryActions = React.createClass({
     });
   },
 
+  onCloseClick: function() {
+    return console.log('test');
+
+  },
+
   render: function() {
     var saveMsg,
         saveBtn,
@@ -106,8 +111,14 @@ var QueryActions = React.createClass({
             <button className="btn btn-default pull-right" role="toggle-viz-config" onClick={this.toggleVizConfig}>
               Customize
             </button>
-            {this.state.showVizConfig ? <KeenVizConfig /> : null }
           </div>
+
+          <div className="row"> 
+            <div className="col-md-12">
+              {this.state.showVizConfig ? <KeenVizConfig onCloseClick={this.onCloseClick} /> : null }
+            </div>
+          </div>
+
         </div>
         {saveMsg}
       </div>

--- a/client/js/app/components/explorer/visualization/index.js
+++ b/client/js/app/components/explorer/visualization/index.js
@@ -14,6 +14,7 @@ var NoticeActions = require('../../../actions/NoticeActions');
 var ExplorerUtils = require('../../../utils/ExplorerUtils');
 var ChartTypeUtils = require('../../../utils/ChartTypeUtils');
 var FormatUtils = require('../../../utils/FormatUtils');
+var KeenVizConfig = require('./keen_viz_config.js')
 
 var Visualization = React.createClass({
 
@@ -158,6 +159,9 @@ var Visualization = React.createClass({
                       hidden={this.props.appState.codeSampleHidden}
                       onCloseClick={this.props.toggleCodeSample}
                       isValid={this.props.model.isValid} />
+          <KeenVizConfig onCloseClick={this.props.toggleVizConfig} 
+                         hidden={this.props.appState.vizConfigHidden}
+          />
         </div>
       </div>
     );

--- a/client/js/app/components/explorer/visualization/keen_viz_config.js
+++ b/client/js/app/components/explorer/visualization/keen_viz_config.js
@@ -16,7 +16,7 @@ var KeenVizConfig = React.createClass({
 
     return (
       <div className={panelClasses}>
-        <a href="#" className="close-btn pull-right" onClick={this.props.onCloseClick}>
+        <a href="#" className="close-btn pull-right" role="close-viz-config" onClick={this.props.onCloseClick}>
           <span className="icon glyphicon glyphicon glyphicon-remove-circle no-margin"></span>
         </a>
         <div className="alert alert-info">Hello, World.</div>

--- a/client/js/app/components/explorer/visualization/keen_viz_config.js
+++ b/client/js/app/components/explorer/visualization/keen_viz_config.js
@@ -1,10 +1,21 @@
 var React = require('react');
+var classNames = require('classnames');
 
 var KeenVizConfig = React.createClass({
 
+  propTypes: {
+    onCloseClick: React.PropTypes.func.isRequired
+  },
+
   render: function() {
     return (
-      <div>Hello, World!</div>
+      <div>
+        <div className="big-notice"> Hello, World!  
+          <a href="#" className="close-btn pull-right" onClick={this.props.onCloseClick}>
+            <span className="icon glyphicon glyphicon glyphicon-remove-circle no-margin"></span>
+          </a>
+        </div>
+      </div>
     );
   }
 

--- a/client/js/app/components/explorer/visualization/keen_viz_config.js
+++ b/client/js/app/components/explorer/visualization/keen_viz_config.js
@@ -4,7 +4,7 @@ var KeenVizConfig = React.createClass({
 
   render: function() {
     return (
-      <div></div>
+      <div>Hello, World!</div>
     );
   }
 

--- a/client/js/app/components/explorer/visualization/keen_viz_config.js
+++ b/client/js/app/components/explorer/visualization/keen_viz_config.js
@@ -4,21 +4,25 @@ var classNames = require('classnames');
 var KeenVizConfig = React.createClass({
 
   propTypes: {
-    onCloseClick: React.PropTypes.func.isRequired
+    onCloseClick: React.PropTypes.func.isRequired,
+    hidden: React.PropTypes.bool.isRequired
   },
 
   render: function() {
+    var panelClasses = classNames({
+      'viz-config-panel': true,
+      'hide': this.props.hidden
+    });
+
     return (
-      <div>
-        <div className="big-notice"> Hello, World!  
-          <a href="#" className="close-btn pull-right" onClick={this.props.onCloseClick}>
-            <span className="icon glyphicon glyphicon glyphicon-remove-circle no-margin"></span>
-          </a>
-        </div>
+      <div className={panelClasses}>
+        <a href="#" className="close-btn pull-right" onClick={this.props.onCloseClick}>
+          <span className="icon glyphicon glyphicon glyphicon-remove-circle no-margin"></span>
+        </a>
+        <div className="alert alert-info">Hello, World.</div>
       </div>
     );
   }
-
 });
 
 module.exports = KeenVizConfig;

--- a/client/js/app/stores/AppStateStore.js
+++ b/client/js/app/stores/AppStateStore.js
@@ -9,6 +9,7 @@ function defaultState() {
   return {
     fetchingPersistedExplorers: false,
     codeSampleHidden: true,
+    vizConfigHidden: true,
     ready: false
   };
 }

--- a/dist/keen-explorer.css
+++ b/dist/keen-explorer.css
@@ -533,7 +533,6 @@
 /*-- Chart --*/
 .c3 svg {
   font: 10px sans-serif;
-  -webkit-tap-highlight-color: transparent;
 }
 .c3 path,
 .c3 line {
@@ -611,11 +610,11 @@
 /*-- Region --*/
 .c3-region {
   fill: steelblue;
-  fill-opacity: .1;
+  fill-opacity: 0.1;
 }
 /*-- Brush --*/
 .c3-brush .extent {
-  fill-opacity: .1;
+  fill-opacity: 0.1;
 }
 /*-- Select - Drag --*/
 /*-- Legend --*/
@@ -630,10 +629,6 @@
   fill: white;
   stroke: lightgray;
   stroke-width: 1;
-}
-/*-- Title --*/
-.c3-title {
-  font: 14px sans-serif;
 }
 /*-- Tooltip --*/
 .c3-tooltip-container {
@@ -816,6 +811,7 @@
 }
 .keen-dataviz .keen-spinner-indicator {
   border-radius: 100%;
+  border: 3px solid #000000;
   border: 3px solid rgba(0, 0, 0, 0.1);
   border-top-color: rgba(0, 0, 0, 0.45);
   box-sizing: border-box;
@@ -862,6 +858,7 @@
   top: 0;
 }
 .keen-c3-legend-label-overlay {
+  background: #ffffff;
   background: rgba(255, 255, 255, 0.9);
   box-shadow: 0 1px 1px rgba(26, 26, 26, 0.1);
   font-family: 'Gotham Rounded SSm A', 'Gotham Rounded SSm B', 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/test/unit/components/explorer/query_actions_spec.js
+++ b/test/unit/components/explorer/query_actions_spec.js
@@ -104,6 +104,12 @@ describe('components/explorer/query_actions', function() {
       TestUtils.Simulate.click($R(this.component).find('[role="toggle-code-sample"]').components[0]);
       assert.isTrue(stub.calledOnce);
     });
+    it('calls toggleVizConfig when the customize button is clicked', function () {
+      var stub = sinon.stub();
+      this.component = this.renderComponent({ toggleVizConfig: stub });
+      TestUtils.Simulate.click($R(this.component).find('[role="toggle-viz-config"]').components[0]);
+      assert.isTrue(stub.calledOnce);
+    });
   });
 
   describe('Button text', function(){

--- a/test/unit/components/explorer/visualization/keen_viz_config_spec.js
+++ b/test/unit/components/explorer/visualization/keen_viz_config_spec.js
@@ -1,8 +1,11 @@
 var KeenVizConfig = require('../../../../../client/js/app/components/explorer/visualization/keen_viz_config.js');
 var assert = require('chai').assert;
 var React = require('react');
+var ReactDOM = require('react-dom');
+var sinon = require('sinon');
 var TestUtils = require('react-addons-test-utils');
 var TestHelpers = require('../../../../support/TestHelpers');
+var $R = require('rquery')(_, React, ReactDOM, TestUtils);
 
 describe('components/explorer/visualization/keen_vis_config', function() {
 
@@ -14,7 +17,16 @@ describe('components/explorer/visualization/keen_vis_config', function() {
     it('is of the right type', function() {
       assert.isTrue(TestUtils.isCompositeComponentWithType(this.component, KeenVizConfig));
     });
+  });
 
+  describe('button callbacks', function() {
+    it('calls toggleVizConfig when the x button is clicked', function () {
+      var stub = sinon.stub();
+      this.component = this.renderComponent({ toggleVizConfig: stub });
+      TestUtils.Simulate.click($R(this.component).find('[role="close-viz-config"]').components[0]);
+      assert.isTrue(stub.calledOnce);
+    });
   });
 
 });
+


### PR DESCRIPTION
## What does this PR do? How does it affect users?

This PR gives users the ability to show and hide the dataviz config component. It is a starting point that does not include styling. 

## How should this be tested?

- Get the project running locally and click on the "Customize" button. 
- You should see a "Hello, World" placeholder notice appear. 
- Confirm that you can close the notice by clicking on the "Customize" button or the "x".
