### PR TITLE
Remove invalid interval parameter from funnel queries

### DIFF
--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -233,6 +233,7 @@ function _removeInvalidFields(newModel) {
     newModel.query.timezone = null;
     newModel.query.group_by = null;
     newModel.query.timeframe = null;
+    newModel.query.interval = null;
   }
   return newModel;
 }

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -1059,12 +1059,12 @@ describe('stores/ExplorerStore', function() {
         assert.sameMembers(explorer.query.group_by, [null]);
       });
 
-      it('should remove the root interval property', function () {
+      it('should set unsupported interval property value to null', function () {
         ExplorerActions.update('abc123', {
           query: {
             analysis_type: 'count',
             event_collection: 'pageviews',
-            interval: 'interval_property',
+            interval: 'interval_value',
             filters: []
           }
         });

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -1059,6 +1059,20 @@ describe('stores/ExplorerStore', function() {
         assert.sameMembers(explorer.query.group_by, [null]);
       });
 
+      it('should remove the root interval property', function () {
+        ExplorerActions.update('abc123', {
+          query: {
+            analysis_type: 'count',
+            event_collection: 'pageviews',
+            interval: 'interval_property',
+            filters: []
+          }
+        });
+        ExplorerActions.update('abc123', { query: { analysis_type: 'funnel' } });
+        var explorer = ExplorerStore.get('abc123');
+        assert.equal(explorer.query.interval, null);
+      });
+
       it('should set the global timeframe property to null', function () {
         ExplorerActions.update('abc123', {
           query: {


### PR DESCRIPTION
## What does this PR do? How does it affect users?

The `interval` parameter is not supported by [funnels](https://keen.io/docs/api/#funnels). This PR removes the invalid `interval` parameter from the Explorer model for this type of query. 

This change resolves the issue saving funnel queries reported in #121. The changes in this PR do not address the issue of toggling the Interval component to a "closed" state when the query builder is cleared out (also reported in #121); I recommend addressing those in a separate PR.

## How should this be tested?

I added a unit test for this change. To test these changes in the browser, create a funnel query and confirm that there is no `interval` set in the URL. 