### PR TITLE
- Added a button to export to CSV

### DIFF
--- a/client/js/app/components/explorer/visualization/chart.js
+++ b/client/js/app/components/explorer/visualization/chart.js
@@ -66,7 +66,8 @@ var Chart = React.createClass({
 		}
 		else {
 	  	chartContent = (
-	  		<KeenViz model={this.props.model} dataviz={this.props.dataviz} />
+	  		<KeenViz model={this.props.model} dataviz={this.props.dataviz}
+	  				exportToCsv={this.props.exportToCsv}/>
 	  	);
 	  }
 

--- a/client/js/app/components/explorer/visualization/index.js
+++ b/client/js/app/components/explorer/visualization/index.js
@@ -14,6 +14,7 @@ var NoticeActions = require('../../../actions/NoticeActions');
 var ExplorerUtils = require('../../../utils/ExplorerUtils');
 var ChartTypeUtils = require('../../../utils/ChartTypeUtils');
 var FormatUtils = require('../../../utils/FormatUtils');
+var DataUtils = require('../../../utils/DataUtils');
 
 var Visualization = React.createClass({
 
@@ -87,6 +88,13 @@ var Visualization = React.createClass({
   componentWillUnmount: function() {
     AppDispatcher.unregister(this.dispatcherToken);
   },
+  
+  exportToCsv: function() {
+	  var data = this.dataviz.dataset.matrix;
+	  var filename = this.props.model.query_name;
+	  
+	  DataUtils.exportToCsv(data, filename);
+  },
 
   render: function() {
     var chartTitle,
@@ -151,7 +159,9 @@ var Visualization = React.createClass({
             </div>
           </div>
           <div className="chart-component">
-            <Chart model={this.props.model} dataviz={this.dataviz} />
+            <Chart model={this.props.model} 
+            		dataviz={this.dataviz}
+            		exportToCsv={this.exportToCsv}/>
           </div>
           <CodeSample ref="codesample"
                       codeSample={codeSample}

--- a/client/js/app/components/explorer/visualization/keen_viz.js
+++ b/client/js/app/components/explorer/visualization/keen_viz.js
@@ -1,5 +1,6 @@
 var _ = require('lodash');
 var React = require('react');
+var ChartTypeUtils = require('../../../utils/ChartTypeUtils');
 
 var KeenViz = React.createClass({
 
@@ -53,8 +54,21 @@ var KeenViz = React.createClass({
   },
 
   render: function() {
+	var exportBtn;
+	
+	if (ChartTypeUtils.isTableChartType(this.props.model.metadata.visualization.chart_type)) {
+	  exportBtn = (
+	    <button type="button" role="export-table" className="btn btn-link" onClick={this.props.exportToCsv}>
+          Export
+        </button>
+      );
+	}
+	
     return (
-      <div ref="keen-viz"></div>
+      <div ref="keen-viz-wrapper">
+      	<div ref="keen-viz"></div>
+      	{exportBtn}
+      </div>
     );
   }
 });

--- a/client/js/app/utils/ChartTypeUtils.js
+++ b/client/js/app/utils/ChartTypeUtils.js
@@ -63,5 +63,9 @@ module.exports = {
 
   responseSupportsChartType: function(query, chartType) {
     return _.includes(module.exports.getChartTypeOptions(query), chartType);
+  },
+  
+  isTableChartType: function(chartType) {
+	  return chartType == 'table';
   }
 }

--- a/client/js/app/utils/DataUtils.js
+++ b/client/js/app/utils/DataUtils.js
@@ -1,0 +1,22 @@
+var _ = require('lodash');
+
+module.exports = {
+  exportToCsv: function(data, filename) {
+	  var csvContent = "data:text/csv;charset=utf-8,";
+	  
+	  data.forEach(function(infoArray, index){
+	     dataString = infoArray.join(",");
+	     csvContent += index < data.length ? dataString+ "\n" : dataString;
+	  }); 
+	  
+	  var encodedUri = encodeURI(csvContent);
+	  var link = document.createElement("a");
+	  
+	  link.setAttribute("href", encodedUri);
+	  link.setAttribute("download", filename);
+	  
+	  document.body.appendChild(link);
+
+	  link.click();
+  }
+}

--- a/test/support/TestHelpers.js
+++ b/test/support/TestHelpers.js
@@ -145,7 +145,9 @@ module.exports = {
       width: 	   function(){ return this; },
       render: 	 function(){ return this; },
       dataType:  function(){ return this; },
-      title:  	 function(){ return this; }
+      title:  	 function(){ return this; },
+      type:      function(){ return this; },
+      sortGroups: function(){ return this; }
     };
   },
 

--- a/test/unit/components/explorer/visualization/index_spec.js
+++ b/test/unit/components/explorer/visualization/index_spec.js
@@ -9,6 +9,7 @@ var AppDispatcher = require('../../../../../client/js/app/dispatcher/AppDispatch
 var AppStateStore = require('../../../../../client/js/app/stores/AppStateStore');
 var ExplorerUtils = require('../../../../../client/js/app/utils/ExplorerUtils');
 var ChartTypeUtils = require('../../../../../client/js/app/utils/ChartTypeUtils');
+var DataUtils = require('../../../../../client/js/app/utils/DataUtils');
 var ExplorerConstants = require('../../../../../client/js/app/constants/ExplorerConstants');
 var ExplorerActions = require('../../../../../client/js/app/actions/ExplorerActions');
 var NoticeActions = require('../../../../../client/js/app/actions/NoticeActions');
@@ -26,6 +27,7 @@ describe('components/explorer/visualization/index', function() {
     this.project = TestHelpers.createProject();
     var datavizStub = sinon.stub(Keen, 'Dataviz').returns(TestHelpers.createDataviz());
     this.chartOptionsStub = sinon.stub(ChartTypeUtils, 'getChartTypeOptions').returns([]);
+    this.exportToCsvStub = sinon.stub(DataUtils, 'exportToCsv').returns([]);
 
     this.renderComponent = function(props) {
       var defaults = {
@@ -53,6 +55,7 @@ describe('components/explorer/visualization/index', function() {
   afterEach(function () {
     Keen.Dataviz.restore();
     ChartTypeUtils.getChartTypeOptions.restore();
+    DataUtils.exportToCsv.restore();
   });
 
   describe('setup', function() {
@@ -111,6 +114,14 @@ describe('components/explorer/visualization/index', function() {
 
       assert.equal(selectField.value, 'metric');
     });
+  });
+  
+  describe('export to csv', function() {
+	 it('exports to csv chart data', function() {
+		 this.component.exportToCsv([['column1', 'column2'], ['row1 value 1', 'row2 value2']]);
+		 
+		 sinon.assert.called(this.exportToCsvStub);
+	 });
   });
 
 });

--- a/test/unit/components/explorer/visualization/keen_viz_spec.js
+++ b/test/unit/components/explorer/visualization/keen_viz_spec.js
@@ -1,0 +1,47 @@
+/** @jsx React.DOM */
+var assert = require('chai').assert;
+var expect = require('chai').expect;
+var _ = require('lodash');
+var sinon = require('sinon');
+var React = require('react');
+var ReactDOM = require('react-dom');
+var KeenViz = require('../../../../../client/js/app/components/explorer/visualization/keen_viz.js');
+var TestUtils = require('react-addons-test-utils');
+var ExplorerUtils = require('../../../../../client/js/app/utils/ExplorerUtils');
+var TestHelpers = require('../../../../support/TestHelpers');
+var $R = require('rquery')(_, React, ReactDOM, TestUtils);
+
+describe('components/explorer/visualization/keen_viz', function() {
+
+  beforeEach(function() {
+	this.model = TestHelpers.createExplorerModel();
+	this.dataviz = TestHelpers.createDataviz();
+	this.exportToCsv = function() { return this; }
+    this.component = TestUtils.renderIntoDocument(<KeenViz model={this.model} dataviz={this.dataviz}
+		exportToCsv={this.exportToCsv}/>);
+		
+	this.exportToCsvStub = sinon.stub(this, 'exportToCsv');
+  });
+
+  describe('export to csv button', function() {
+	it('expor to csv button is not shown when chart type is different than table', function() {
+		assert.lengthOf($R(this.component).find('[role="export-table"]').components, 0);
+	});
+    it('export to csv button is shown when char type table is selected', function() {
+    	this.model.metadata.visualization.chart_type = 'table';
+    	this.component = TestUtils.renderIntoDocument(<KeenViz model={this.model} dataviz={this.dataviz}
+    		exportToCsv={this.exportToCsv}/>);
+    				
+    	assert.lengthOf($R(this.component).find('[role="export-table"]').components, 1);
+    });
+    it('export to csv button calls export to csv function', function() {
+    	this.model.metadata.visualization.chart_type = 'table';
+    	this.component = TestUtils.renderIntoDocument(<KeenViz model={this.model} dataviz={this.dataviz}
+    		exportToCsv={this.exportToCsv}/>);
+    	
+    	TestUtils.Simulate.click($R(this.component).find('[role="export-table"]').components[0]);
+    	
+    	sinon.assert.called(this.exportToCsvStub);
+    });
+  });
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -64,6 +64,7 @@ require('./components/explorer/query_builder/funnels/funnel_builder_spec.js');
 require('./components/explorer/query_builder/funnels/funnel_step_spec.js');
 require('./components/explorer/saved_queries/browse_queries_spec.js');
 require('./components/explorer/visualization/chart_spec.js');
+require('./components/explorer/visualization/keen_viz_spec.js');
 require('./components/explorer/visualization/index_spec.js');
 
 // Common


### PR DESCRIPTION
What does this PR do? How does it affect users?

It implements an Export to CSV function for for table chart type, the user is able to use the new Export button to open or download a CSV file.

How should this be tested?

Thinking in UAT this should be tested, first making sure the button only appears when Table chart type is selected for the current query loaded.

I´ve created some tests checking ExportToCsv function is called as well as ensuring Export button only appears when table chart type is selected.

There few things to be taken into account, I´ve used a very simple way to generate the CSV file, this could be improved integrating a library if really needed, this code is in a new file created DataUtils.js and this is the only thing not tested in the spec files in the solution. The other bit I´m not quite sure it is the best solution is related to the check if the dataviz shown in the table type, it is checked through the metadata in the model (model.metadata.visualization.chart_type) but it could be (probably) done by dataviz.type.

Related tickets?

I´ve made the decision to implement this feature because I've seen the ticket #94 where it was requested.