### PR TITLE
Clone saved query feature

### DIFF
--- a/client/js/app/actions/ExplorerActions.js
+++ b/client/js/app/actions/ExplorerActions.js
@@ -26,6 +26,18 @@ var ExplorerActions = {
       models: models
     });
   },
+  
+  clone: function(sourceId) {
+	AppDispatcher.dispatch({
+	  actionType: ExplorerConstants.EXPLORER_CLONE,
+	  id: sourceId
+	});
+	NoticeActions.create({
+      text: "Query cloned! Set a name for this cloned query and save it",
+      type: 'success',
+      icon: 'check'
+    });
+  },
 
   update: function(id, updates) {
     var updated_query, project = ProjectStore.getProject();

--- a/client/js/app/actions/ExplorerActions.js
+++ b/client/js/app/actions/ExplorerActions.js
@@ -33,7 +33,7 @@ var ExplorerActions = {
 	  id: sourceId
 	});
 	NoticeActions.create({
-      text: "Query cloned! Set a name for this cloned query and save it.",
+      text: "Query cloned! Add a name for this cloned query and save it.",
       type: 'success',
       icon: 'check'
     });

--- a/client/js/app/actions/ExplorerActions.js
+++ b/client/js/app/actions/ExplorerActions.js
@@ -28,11 +28,11 @@ var ExplorerActions = {
   },
   
   clone: function(sourceId) {
-	AppDispatcher.dispatch({
-	  actionType: ExplorerConstants.EXPLORER_CLONE,
-	  id: sourceId
-	});
-	NoticeActions.create({
+    AppDispatcher.dispatch({
+      actionType: ExplorerConstants.EXPLORER_CLONE,
+      id: sourceId
+    });
+    NoticeActions.create({
       text: "Query cloned! Add a name for this cloned query and save it.",
       type: 'success',
       icon: 'check'

--- a/client/js/app/actions/ExplorerActions.js
+++ b/client/js/app/actions/ExplorerActions.js
@@ -33,7 +33,7 @@ var ExplorerActions = {
 	  id: sourceId
 	});
 	NoticeActions.create({
-      text: "Query cloned! Set a name for this cloned query and save it",
+      text: "Query cloned! Set a name for this cloned query and save it.",
       type: 'success',
       icon: 'check'
     });

--- a/client/js/app/components/explorer/index.js
+++ b/client/js/app/components/explorer/index.js
@@ -82,6 +82,14 @@ var Explorer = React.createClass({
     event.preventDefault();
     ExplorerActions.save(this.props.persistence, this.state.activeExplorer.id);
   },
+  
+  cloneQueryClick: function(event) {
+	event.preventDefault();
+	ExplorerActions.clone(this.state.activeExplorer.id);
+    var newExplorer = ExplorerStore.getLast();
+    ExplorerActions.setActive(newExplorer.id);
+    this.setState({ activeQueryPane: 'build' });
+  },
 
   createNewQuery: function(event) {
     event.preventDefault();
@@ -308,6 +316,7 @@ var Explorer = React.createClass({
                           handleQuerySubmit={this.handleQuerySubmit}
                           saveQueryClick={this.saveQueryClick}
                           removeClick={this.removeSavedQueryClicked}
+                          cloneQueryClick={this.cloneQueryClick}
                           persistence={this.props.persistence}
                           codeSampleHidden={this.state.appState.codeSampleHidden}
                           toggleCodeSample={this.toggleCodeSample} />

--- a/client/js/app/components/explorer/index.js
+++ b/client/js/app/components/explorer/index.js
@@ -84,8 +84,8 @@ var Explorer = React.createClass({
   },
   
   cloneQueryClick: function(event) {
-	event.preventDefault();
-	ExplorerActions.clone(this.state.activeExplorer.id);
+    event.preventDefault();
+    ExplorerActions.clone(this.state.activeExplorer.id);
     var newExplorer = ExplorerStore.getLast();
     ExplorerActions.setActive(newExplorer.id);
     this.setState({ activeQueryPane: 'build' });

--- a/client/js/app/components/explorer/query_actions.js
+++ b/client/js/app/components/explorer/query_actions.js
@@ -72,7 +72,7 @@ var QueryActions = React.createClass({
       );
       if (isPersisted) {
         cloneBtn = (
-          <button type="button" className="btn btn-primary" onClick={actionsSupported ? this.props.cloneQueryClick : function(){}} role="clone-query" disabled={this.props.model.loading || !actionsSupported}>
+          <button type="button" className="btn btn-default" onClick={actionsSupported ? this.props.cloneQueryClick : function(){}} role="clone-query" disabled={this.props.model.loading || !actionsSupported}>
             Clone
           </button>
         );

--- a/client/js/app/components/explorer/query_actions.js
+++ b/client/js/app/components/explorer/query_actions.js
@@ -35,6 +35,7 @@ var QueryActions = React.createClass({
   render: function() {
     var saveMsg,
         saveBtn,
+        cloneBtn,
         deleteBtn,
         actionsSupported = true,
         runButtonClasses = classNames({
@@ -69,6 +70,13 @@ var QueryActions = React.createClass({
           Delete
         </button>
       );
+      if (isPersisted) {
+        cloneBtn = (
+          <button type="button" className="btn btn-primary" onClick={actionsSupported ? this.props.cloneQueryClick : function(){}} role="clone-query" disabled={this.props.model.loading || !actionsSupported}>
+            Clone
+          </button>
+        );
+      }
     }
 
     return (
@@ -82,6 +90,7 @@ var QueryActions = React.createClass({
             </div>
             <div className="manage-group pull-left">
               {saveBtn}
+              {cloneBtn}
               {deleteBtn}
             </div>
           </div>

--- a/client/js/app/constants/ExplorerConstants.js
+++ b/client/js/app/constants/ExplorerConstants.js
@@ -3,6 +3,7 @@ var keyMirror = require('keymirror');
 module.exports = keyMirror({
   EXPLORER_CREATE: null,
   EXPLORER_CREATE_BATCH: null,
+  EXPLORER_CLONE: null,
   EXPLORER_UPDATE: null,
   EXPLORER_REMOVE: null,
   EXPLORER_SET_ACTIVE: null,

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -100,16 +100,6 @@ function _defaultStep() {
   }
 }
 
-/**
- * Clone the query attributes to a new object.
- * @param {Object} source  Source object from get the data to be copied.
- * @returns {Object} Copy of the query attributes of th source object
- */
-function _cloneAttrs(source) {
-	return {
-	    query: source.query
-	};
-}
 
 function _validate(id) {
   RunValidations(ExplorerValidations, _explorers[id]);
@@ -551,7 +541,7 @@ ExplorerStore.dispatchToken = AppDispatcher.register(function(action) {
       
     case ExplorerConstants.EXPLORER_CLONE:
       var source = ExplorerStore.get(action.id);
-      _create(_cloneAttrs(source));
+      _create({ query: _.cloneDeep(source.query) });
       finishAction();
       break;
 

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -542,7 +542,7 @@ ExplorerStore.dispatchToken = AppDispatcher.register(function(action) {
     case ExplorerConstants.EXPLORER_CLONE:
       var source = ExplorerStore.get(action.id);
       _create({ query: _.cloneDeep(source.query), 
-                metadata : {
+                metadata: {
                   display_name: null,
                   visualization: {
                     chart_type: _.cloneDeep(source.metadata.visualization.chart_type) 

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -541,7 +541,14 @@ ExplorerStore.dispatchToken = AppDispatcher.register(function(action) {
       
     case ExplorerConstants.EXPLORER_CLONE:
       var source = ExplorerStore.get(action.id);
-      _create({ query: _.cloneDeep(source.query) });
+      _create({ query: _.cloneDeep(source.query), 
+                metadata : {
+                  display_name: null,
+                  visualization: {
+                    chart_type: _.cloneDeep(source.metadata.visualization.chart_type) 
+                  }
+                }
+              });
       finishAction();
       break;
 

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -100,6 +100,17 @@ function _defaultStep() {
   }
 }
 
+/**
+ * Clone the query attributes to a new object.
+ * @param {Object} source  Source object from get the data to be copied.
+ * @returns {Object} Copy of the query attributes of th source object
+ */
+function _cloneAttrs(source) {
+	return {
+	    query: source.query
+	};
+}
+
 function _validate(id) {
   RunValidations(ExplorerValidations, _explorers[id]);
 }
@@ -535,6 +546,12 @@ ExplorerStore.dispatchToken = AppDispatcher.register(function(action) {
       action.models.forEach(function(model) {
         _explorers[model.id] ? _update(model.id, model) : _create(model);        
       });
+      finishAction();
+      break;
+      
+    case ExplorerConstants.EXPLORER_CLONE:
+      var source = ExplorerStore.get(action.id);
+      _create(_cloneAttrs(source));
       finishAction();
       break;
 

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -543,7 +543,6 @@ ExplorerStore.dispatchToken = AppDispatcher.register(function(action) {
       var source = ExplorerStore.get(action.id);
       _create({ query: _.cloneDeep(source.query), 
                 metadata : {
-                  display_name: null,
                   visualization: {
                     chart_type: _.cloneDeep(source.metadata.visualization.chart_type) 
                   }

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -543,6 +543,7 @@ ExplorerStore.dispatchToken = AppDispatcher.register(function(action) {
       var source = ExplorerStore.get(action.id);
       _create({ query: _.cloneDeep(source.query), 
                 metadata : {
+                  display_name: null,
                   visualization: {
                     chart_type: _.cloneDeep(source.metadata.visualization.chart_type) 
                   }

--- a/test/unit/actions/ExplorerActionsSpec.js
+++ b/test/unit/actions/ExplorerActionsSpec.js
@@ -468,5 +468,15 @@ describe('actions/ExplorerActions', function() {
 
       });
     });
+    
+    describe('clone a saved query', function () {
+        it('should dispatch an EXPLORER_CLONE event', function () {
+          ExplorerActions.clone('ABC');
+          assert.isTrue(this.dispatchStub.calledWith({
+            actionType: 'EXPLORER_CLONE',
+            id: 'ABC'
+          }));
+        });
+    });
   });
 });

--- a/test/unit/components/explorer/index_spec.js
+++ b/test/unit/components/explorer/index_spec.js
@@ -264,7 +264,6 @@ describe('components/explorer/index', function() {
     });
       
     describe('cloneQueryClick', function () {
-
       beforeEach(function() {
         ExplorerStore.clearAll();
         ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'abc', metadata: { display_name: 'abc' } }));

--- a/test/unit/components/explorer/index_spec.js
+++ b/test/unit/components/explorer/index_spec.js
@@ -262,6 +262,47 @@ describe('components/explorer/index', function() {
       });
 
     });
+      
+    describe('cloneQueryClick', function () {
+      beforeEach(function() {
+        ExplorerStore.clearAll();
+        ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'abc', metadata: { display_name: 'abc' } }));
+        ExplorerActions.setActive('abc');
+        ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'def', metadata: { display_name: 'def' } }));
+        ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'ghi', metadata: { display_name: 'ghi' } }));
+
+        var props = _.assign({}, this.component.props, { persistence: {} });
+        this.component = TestHelpers.renderComponent(Explorer, props);
+      });
+      it('should add a new explorer in the store', function () {
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        assert.strictEqual(_.keys(ExplorerStore.getAll()).length, 4);
+      });
+      it('should set the newly created explorer as active', function () {
+        var stub = sinon.stub(ExplorerActions, 'setActive');
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        var keys = _.keys(ExplorerStore.getAll());
+        var lastExplorer = ExplorerStore.getAll()[keys[keys.length-1]];
+        assert.isTrue(stub.calledWith(lastExplorer.id));
+        ExplorerActions.setActive.restore();
+      });
+      it('should change the text on the query builder tab to "Create a new query"', function () {
+        assert.strictEqual(this.component.refs['query-pane-tabs'].refs['build-tab'].textContent, 'Edit query');
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        this.component._onChange();
+        assert.strictEqual(this.component.refs['query-pane-tabs'].refs['build-tab'].textContent, 'Create a new query');
+      });
+      it('should update component state to show the build tab', function () {
+        this.component.setState({ activeQueryPane: 'browse' });
+        this.component.cloneQueryClick(TestHelpers.fakeEvent());
+        assert.strictEqual(this.component.state.activeQueryPane, 'build');
+      });
+      it('should call clone method passing current or active explorer', function() {
+    	  var cloneStub = sinon.stub(ExplorerActions, 'clone');
+    	  this.component.cloneQueryClick(TestHelpers.fakeEvent());
+    	  assert.isTrue(cloneStub.calledWith('abc'));
+      });
+    });
 
     describe('createNewQuery', function () {
       beforeEach(function() {

--- a/test/unit/components/explorer/index_spec.js
+++ b/test/unit/components/explorer/index_spec.js
@@ -264,6 +264,7 @@ describe('components/explorer/index', function() {
     });
       
     describe('cloneQueryClick', function () {
+
       beforeEach(function() {
         ExplorerStore.clearAll();
         ExplorerActions.create(_.assign({}, TestHelpers.createExplorerModel(), { id: 'abc', metadata: { display_name: 'abc' } }));
@@ -274,10 +275,12 @@ describe('components/explorer/index', function() {
         var props = _.assign({}, this.component.props, { persistence: {} });
         this.component = TestHelpers.renderComponent(Explorer, props);
       });
+
       it('should add a new explorer in the store', function () {
         this.component.cloneQueryClick(TestHelpers.fakeEvent());
         assert.strictEqual(_.keys(ExplorerStore.getAll()).length, 4);
       });
+
       it('should set the newly created explorer as active', function () {
         var stub = sinon.stub(ExplorerActions, 'setActive');
         this.component.cloneQueryClick(TestHelpers.fakeEvent());
@@ -286,17 +289,20 @@ describe('components/explorer/index', function() {
         assert.isTrue(stub.calledWith(lastExplorer.id));
         ExplorerActions.setActive.restore();
       });
+
       it('should change the text on the query builder tab to "Create a new query"', function () {
         assert.strictEqual(this.component.refs['query-pane-tabs'].refs['build-tab'].textContent, 'Edit query');
         this.component.cloneQueryClick(TestHelpers.fakeEvent());
         this.component._onChange();
         assert.strictEqual(this.component.refs['query-pane-tabs'].refs['build-tab'].textContent, 'Create a new query');
       });
+
       it('should update component state to show the build tab', function () {
         this.component.setState({ activeQueryPane: 'browse' });
         this.component.cloneQueryClick(TestHelpers.fakeEvent());
         assert.strictEqual(this.component.state.activeQueryPane, 'build');
       });
+
       it('should call clone method passing current or active explorer', function() {
     	  var cloneStub = sinon.stub(ExplorerActions, 'clone');
     	  this.component.cloneQueryClick(TestHelpers.fakeEvent());

--- a/test/unit/components/explorer/query_actions_spec.js
+++ b/test/unit/components/explorer/query_actions_spec.js
@@ -52,6 +52,9 @@ describe('components/explorer/query_actions', function() {
           it('does not show the delete button if persistence is null', function () {
             assert.lengthOf($R(this.component).find('[role="delete-query"]').components, 0);
           });
+          it('does not show the clone button if persistence is null', function () {
+            assert.lengthOf($R(this.component).find('[role="clone-query"]').components, 0);
+          });
         });
         describe('with persistence', function () {
           it('does show the save button', function () {
@@ -61,6 +64,10 @@ describe('components/explorer/query_actions', function() {
           it('does show the delete button', function () {
             this.component = this.renderComponent({ persistence: {} });
             assert.lengthOf($R(this.component).find('[role="delete-query"]').components, 1);
+          });
+          it('does show the clone button', function () {
+            this.component = this.renderComponent({ persistence: {} });
+            assert.lengthOf($R(this.component).find('[role="clone-query"]').components, 1);
           });
           describe('if the query is an email extraction', function () {
             it('the save button is disabled', function () {

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -132,6 +132,7 @@ describe('stores/ExplorerStore', function() {
   	      analysis_type: 'count'
   		  },
         metadata: {
+          display_name: 'Test',
           visualization: {
             chart_type: 'metric'
           }
@@ -139,8 +140,8 @@ describe('stores/ExplorerStore', function() {
   	  });
   	  var source = ExplorerStore.get('abc123');
   	  ExplorerActions.clone(source.id);
+      var clone = ExplorerStore.getLast();
   	  var keys = Object.keys(ExplorerStore.getAll());
-      var clone = ExplorerStore.getAll()[keys[1]];
       assert.lengthOf(keys, 2);
       assert.isTrue(clone.id !== source.id);
       assert.deepPropertyNotVal(clone, 'id', 'abc123');
@@ -148,6 +149,7 @@ describe('stores/ExplorerStore', function() {
       assert.deepPropertyVal(clone, 'query_name', null);
       assert.deepPropertyVal(clone, 'query.event_collection', 'signups');
       assert.deepPropertyVal(clone, 'query.analysis_type', 'count');
+      assert.deepPropertyVal(clone, 'metadata.display_name', null);
       assert.deepPropertyVal(clone, 'metadata.visualization.chart_type', 'metric');
     });
     it('should clone query into a new object and not modify original object', function() {
@@ -159,6 +161,7 @@ describe('stores/ExplorerStore', function() {
           analysis_type: 'count'
         },
         metadata: {
+          display_name: 'Another Test',
           visualization: {
             chart_type: 'metric'
           }
@@ -166,14 +169,16 @@ describe('stores/ExplorerStore', function() {
       });
       var source = ExplorerStore.get('abc456');
       ExplorerActions.clone(source.id);
+      var clone = ExplorerStore.getLast();
       var keys = Object.keys(ExplorerStore.getAll());
-      var clone = ExplorerStore.getAll()[keys[1]]
+      assert.lengthOf(keys, 2);
       assert.notStrictEqual(source.query, clone.query);
       assert.notStrictEqual(source.metadata.visualization, clone.metadata.visualization);
       assert.deepPropertyVal(source, 'id','abc456');
       assert.deepPropertyVal(source, 'query_name', 'Another Test Query'); 
       assert.deepPropertyVal(source, 'query.event_collection', 'signups');
       assert.deepPropertyVal(source, 'query.analysis_type', 'count');
+      assert.deepPropertyVal(source, 'metadata.display_name', 'Another Test');
       assert.deepPropertyVal(source, 'metadata.visualization.chart_type', 'metric');
     });
   });

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -121,6 +121,25 @@ describe('stores/ExplorerStore', function() {
       assert.typeOf(ExplorerStore.get('abc123').query.percentile, 'number');
     });
   });
+  
+  describe('clone', function () {
+	it('should clone only query data', function() {
+	  ExplorerActions.create({
+	    id: 'abc123',
+	    query: {
+		  event_collection: 'signups',
+	      analysis_type: 'count'
+		}
+	  });
+	  var source = ExplorerStore.get('abc123');
+	  ExplorerActions.clone(source.id);
+	  var keys = Object.keys(ExplorerStore.getAll());
+	  assert.lengthOf(Object.keys(ExplorerStore.getAll()), 2);
+	  assert.isTrue(ExplorerStore.getAll()[keys[keys.length - 1]].id != source.id);
+      assert.deepPropertyVal(ExplorerStore.getAll()[keys[keys.length - 1]], 'query.event_collection', 'signups');
+      assert.deepPropertyVal(ExplorerStore.getAll()[keys[keys.length - 1]], 'query.analysis_type', 'count');
+	})
+  });
 
   describe('createBatch', function () {
     it('should create a model for every object in the array under the key "models"', function () {

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -123,22 +123,59 @@ describe('stores/ExplorerStore', function() {
   });
   
   describe('clone', function () {
-	it('should clone only query data', function() {
-	  ExplorerActions.create({
-	    id: 'abc123',
-	    query: {
-		  event_collection: 'signups',
-	      analysis_type: 'count'
-		}
-	  });
-	  var source = ExplorerStore.get('abc123');
-	  ExplorerActions.clone(source.id);
-	  var keys = Object.keys(ExplorerStore.getAll());
-	  assert.lengthOf(Object.keys(ExplorerStore.getAll()), 2);
-	  assert.isTrue(ExplorerStore.getAll()[keys[keys.length - 1]].id != source.id);
-      assert.deepPropertyVal(ExplorerStore.getAll()[keys[keys.length - 1]], 'query.event_collection', 'signups');
-      assert.deepPropertyVal(ExplorerStore.getAll()[keys[keys.length - 1]], 'query.analysis_type', 'count');
-	})
+  	it('should only clone query data and metadata.visualization.chart_type', function() {
+  	  ExplorerActions.create({
+  	    id: 'abc123',
+        query_name: 'Test Query',
+  	    query: {
+  		  event_collection: 'signups',
+  	      analysis_type: 'count'
+  		  },
+        metadata: {
+          visualization: {
+            chart_type: 'metric'
+          }
+        }
+  	  });
+  	  var source = ExplorerStore.get('abc123');
+  	  ExplorerActions.clone(source.id);
+  	  var keys = Object.keys(ExplorerStore.getAll());
+      var clone = ExplorerStore.getAll()[keys[1]];
+      assert.lengthOf(keys, 2);
+      assert.isTrue(clone.id !== source.id);
+      assert.deepPropertyNotVal(clone, 'id', 'abc123');
+      assert.deepPropertyNotVal(clone, 'query_name', 'Test Query');
+      assert.deepPropertyVal(clone, 'query_name', null);
+      assert.deepPropertyVal(clone, 'query.event_collection', 'signups');
+      assert.deepPropertyVal(clone, 'query.analysis_type', 'count');
+      assert.deepPropertyVal(clone, 'metadata.visualization.chart_type', 'metric');
+    });
+    it('should clone query into a new object and not modify original object', function() {
+      ExplorerActions.create({
+        id: 'abc456',
+        query_name: 'Another Test Query',
+        query: {
+        event_collection: 'signups',
+          analysis_type: 'count'
+        },
+        metadata: {
+          visualization: {
+            chart_type: 'metric'
+          }
+        }
+      });
+      var source = ExplorerStore.get('abc456');
+      ExplorerActions.clone(source.id);
+      var keys = Object.keys(ExplorerStore.getAll());
+      var clone = ExplorerStore.getAll()[keys[1]]
+      assert.notStrictEqual(source.query, clone.query);
+      assert.notStrictEqual(source.metadata.visualization, clone.metadata.visualization);
+      assert.deepPropertyVal(source, 'id','abc456');
+      assert.deepPropertyVal(source, 'query_name', 'Another Test Query'); 
+      assert.deepPropertyVal(source, 'query.event_collection', 'signups');
+      assert.deepPropertyVal(source, 'query.analysis_type', 'count');
+      assert.deepPropertyVal(source, 'metadata.visualization.chart_type', 'metric');
+    });
   });
 
   describe('createBatch', function () {

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -122,26 +122,28 @@ describe('stores/ExplorerStore', function() {
     });
   });
   
-  describe('clone', function () {
-  	it('should only clone query data and metadata.visualization.chart_type', function() {
-  	  ExplorerActions.create({
-  	    id: 'abc123',
+  describe('clone', function() {
+    it('should only clone query data and metadata.visualization.chart_type', function() {
+      ExplorerActions.create({
+        id: 'abc123',
         query_name: 'Test Query',
-  	    query: {
-  		  event_collection: 'signups',
-  	      analysis_type: 'count'
-  		  },
+        query: {
+        event_collection: 'signups',
+          analysis_type: 'count'
+        },
         metadata: {
           display_name: 'Test',
           visualization: {
             chart_type: 'metric'
           }
         }
-  	  });
-  	  var source = ExplorerStore.get('abc123');
-  	  ExplorerActions.clone(source.id);
+      });
+
+      var source = ExplorerStore.get('abc123');
+      ExplorerActions.clone(source.id);
       var clone = ExplorerStore.getLast();
-  	  var keys = Object.keys(ExplorerStore.getAll());
+      var keys = Object.keys(ExplorerStore.getAll());
+
       assert.lengthOf(keys, 2);
       assert.isTrue(clone.id !== source.id);
       assert.deepPropertyNotVal(clone, 'id', 'abc123');
@@ -152,12 +154,13 @@ describe('stores/ExplorerStore', function() {
       assert.deepPropertyVal(clone, 'metadata.display_name', null);
       assert.deepPropertyVal(clone, 'metadata.visualization.chart_type', 'metric');
     });
+
     it('should clone query into a new object and not modify original object', function() {
       ExplorerActions.create({
         id: 'abc456',
         query_name: 'Another Test Query',
         query: {
-        event_collection: 'signups',
+          event_collection: 'signups',
           analysis_type: 'count'
         },
         metadata: {
@@ -167,10 +170,12 @@ describe('stores/ExplorerStore', function() {
           }
         }
       });
+
       var source = ExplorerStore.get('abc456');
       ExplorerActions.clone(source.id);
       var clone = ExplorerStore.getLast();
       var keys = Object.keys(ExplorerStore.getAll());
+
       assert.lengthOf(keys, 2);
       assert.notStrictEqual(source.query, clone.query);
       assert.notStrictEqual(source.metadata.visualization, clone.metadata.visualization);


### PR DESCRIPTION
## What does this PR do?

This PR builds off of https://github.com/keen/explorer/pull/180, a PR created by @menismu, which offers users the ability to clone saved queries. This feature was requested in https://github.com/keen/explorer/issues/151. Many thanks to @menismu for implementing this feature!

The updates in this PR include:

- Makes the clone button white.
- A small update to the clone success message copy.
- Uses `_.cloneDeep` to ensure the source query and newly cloned query reference different objects.
- Clones `metadata.visualization.chart_type` to ensure that cloned queries have the original query visualization type set as default. This also resolves an issue where cloned queries were inconsistently displaying the error "A chart type is required. Check out the .type() method." in the UI.
- Adds some additional test coverage for the changes noted above.

![screen shot 2016-12-20 at 12 36 34 pm](https://cloud.githubusercontent.com/assets/6183404/21367264/54165278-c6b2-11e6-8f1b-bab3748ddda7.png)

## How should this be tested?

- Get the branch running locally and run the tests with `npm run test`.
- QA cloning saved queries in the browser. Test several user flows (e.g. clone a clone, update the original query after it has been cloned, delete a clone, etc).

## Related Tickets
https://github.com/keen/explorer/pull/180, #151 
