### PR TITLE
remove null values when we turn the group_by into an array

### DIFF
--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -282,7 +282,7 @@ function _prepareFilterUpdates(explorer, filter, updates) {
 
 function _wrapGroupBy(group_by) {
   if (!_.isArray(group_by)) group_by = [group_by];
-  return _.remove(group_by, null);
+  return _.pull(group_by, null);
 }
 
 function _create(attrs) {

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -282,7 +282,7 @@ function _prepareFilterUpdates(explorer, filter, updates) {
 
 function _wrapGroupBy(group_by) {
   if (!_.isArray(group_by)) group_by = [group_by];
-  return group_by;
+  return _.remove(group_by, null);
 }
 
 function _create(attrs) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "classnames": "2.1.2",
     "flux": "^2.0.3",
     "json-stable-stringify": "1.0.0",
-    "keen-analysis": "^1.1.0",
+    "keen-analysis": "1.1.0",
     "keen-dataviz": "^1.0.4",
     "keymirror": "~0.1.0",
     "lodash": "4.0.0",

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -92,6 +92,16 @@ describe('stores/ExplorerStore', function() {
       var keys = Object.keys(ExplorerStore.getAll());
       assert.equal(ExplorerStore.getAll()[keys[0]].query.group_by.length, 0);
     });
+    it('should wrap non-null group_by values in an array', function () {
+      ExplorerActions.create({
+        query: {
+          group_by: 'thing'
+        }
+      });
+      var keys = Object.keys(ExplorerStore.getAll());
+      assert.equal(ExplorerStore.getAll()[keys[0]].query.group_by.length, 1);
+      assert.equal(ExplorerStore.getAll()[keys[0]].query.group_by[0], 'thing');
+    });
     it('should set the store object key to the id is one is passed in', function () {
       ExplorerActions.create({
         id: 'abc123'

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -83,6 +83,15 @@ describe('stores/ExplorerStore', function() {
       assert.deepPropertyVal(ExplorerStore.getAll()[keys[0]], 'query.analysis_type', 'count');
       assert.deepPropertyVal(ExplorerStore.getAll()[keys[0]], 'metadata.visualization.chart_type', 'metric');
     });
+    it('should translate a null group_by to an empty array', function () {
+      ExplorerActions.create({
+        query: {
+          group_by: null
+        }
+      });
+      var keys = Object.keys(ExplorerStore.getAll());
+      assert.equal(ExplorerStore.getAll()[keys[0]].query.group_by.length, 0);
+    });
     it('should set the store object key to the id is one is passed in', function () {
       ExplorerActions.create({
         id: 'abc123'
@@ -521,7 +530,7 @@ describe('stores/ExplorerStore', function() {
         ExplorerActions.update('SOME_ID', updates);
 
         assert.deepPropertyVal(ExplorerStore.get('SOME_ID'), 'query.interval', null);
-        assert.sameMembers(ExplorerStore.get('SOME_ID').query.group_by, [null]);
+        assert.sameMembers(ExplorerStore.get('SOME_ID').query.group_by, []);
       });
       it('should set percentile to null if the analysis type is not percentile', function () {
         ExplorerActions.create({
@@ -1122,7 +1131,7 @@ describe('stores/ExplorerStore', function() {
         });
         ExplorerActions.update('abc123', { query: { analysis_type: 'funnel' } });
         var explorer = ExplorerStore.get('abc123');
-        assert.sameMembers(explorer.query.group_by, [null]);
+        assert.sameMembers(explorer.query.group_by, []);
       });
 
       it('should set unsupported interval property value to null', function () {


### PR DESCRIPTION
## What does this PR do? How does it affect users?
Saved queries will represent `group_by` as a `null` for queries without a group_by value. Explorer tries to be smart by turning non-array `group_by` values into single-element arrays, but makes the poor mistake of wrapping `null` `group_by`s into an array. That messes things up down the line, specifically causing Explorer to think the query is categorial (has a group_by).

This change removes `null` values from the `group_by` array. Effectively, for users, that means they will get the correct chart type options for their `singular` saved queries.

## How should this be tested?

Pull it down, and create a regular ol' count query with a metric type. Save it. The chart type should still be metric. If it's not we have trouble.

I'd also suggest trying a few other query types, just to watch for unintended consequences.

Step through the code line by line. Things to keep in mind as you review:
 - Are there any edge cases not covered by this code?
 - Does this code follow conventions (naming, formatting, modularization, etc) where applicable?

Fetch the branch and/or deploy to staging to test the following:

- [ ] Does the code compile without warnings (check shell, console)?
- [ ] Do all tests pass?
- [ ] Does the UI, pixel by pixel, look exactly as expected (check various screen sizes, including mobile)?
- [ ] If the feature makes requests from the browser, inspect them in the Web Inspector. Do they look as expected (parameters, headers, etc)?
- [ ] If the feature sends data to Keen, is the data visible in the project if you run an extraction (include link to collection/query)?
- [ ] If the feature saves data to a database, can you confirm the data is indeed created in the database?

## Related tickets?
#192 (JIRA #520)