### PR TITLE
Disable native autocomplete for all input fields

### DIFF
--- a/client/js/app/components/common/datepicker.js
+++ b/client/js/app/components/common/datepicker.js
@@ -72,7 +72,8 @@ var Datepicker = React.createClass({
                onChange={this.props.onChange}
                onBlur={this.handleOnBlur}
                onFocus={this.onFocus}
-               placeholder={this.props.placeholder} />
+               placeholder={this.props.placeholder}
+               autoComplete="off" />
         {errorMsg}
       </div>
     );

--- a/client/js/app/components/common/event_browser.js
+++ b/client/js/app/components/common/event_browser.js
@@ -153,7 +153,7 @@ var EventBrowser = React.createClass({
       <div className="event-browser" onKeyUp={this.handleKeyUp}>
         <div className="event-names">
           <div className="search-box">
-            <input type="text" name="search" ref="search-box" placeholder="Search..." onChange={this.setSearchText} />
+            <input type="text" name="search" ref="search-box" placeholder="Search..." onChange={this.setSearchText} autoComplete="off" />
             <span className="glyphicon glyphicon-search icon"></span>
           </div>
           <ul className="nav nav-pills nav-stacked event-names-list" ref="event-names-list">
@@ -183,7 +183,7 @@ var EventBrowser = React.createClass({
 
     var alertContent = (
       <div className="alert alert-info no-margin no-collections-alert">
-        There is no data to preview. This project does not have any event collections. 
+        There is no data to preview. This project does not have any event collections.
       </div>
     );
 

--- a/client/js/app/components/common/filter_value_fields.js
+++ b/client/js/app/components/common/filter_value_fields.js
@@ -120,7 +120,8 @@ var FilterValueFields = React.createClass({
                onChange={this.setValueState}
                onBlur={this.handleChangeWithEvent}
                placeholder={this.getInputPlaceholder()}
-               readOnly={this.props.filter.coercion_type === 'Null'}/>
+               readOnly={this.props.filter.coercion_type === 'Null'}
+               autoComplete="off" />
       );
     }
 

--- a/client/js/app/components/common/geo.js
+++ b/client/js/app/components/common/geo.js
@@ -13,7 +13,8 @@ var Geo = React.createClass({
                  name="coordinates.0"
                  className="form-control"
                  value={this.props.filter.property_value.coordinates[0] || ""}
-                 onChange={this.props.handleChange} />
+                 onChange={this.props.handleChange}
+                 autoComplete="off" />
         </div>
         <div className="col-md-12">
           <label htmlFor="amount">Latitude</label>
@@ -21,7 +22,8 @@ var Geo = React.createClass({
                  name="coordinates.1"
                  className="form-control"
                  value={this.props.filter.property_value.coordinates[1] || ""}
-                 onChange={this.props.handleChange} />
+                 onChange={this.props.handleChange}
+                 autoComplete="off" />
         </div>
         <div className="col-md-12">
           <label htmlFor="amount">Radius in Miles</label>
@@ -29,7 +31,8 @@ var Geo = React.createClass({
                  name="max_distance_miles"
                  className="form-control"
                  value={this.props.filter.property_value.max_distance_miles || ""}
-                 onChange={this.props.handleChange} />
+                 onChange={this.props.handleChange}
+                 autoComplete="off" />
         </div>
       </div>
     );

--- a/client/js/app/components/common/input.js
+++ b/client/js/app/components/common/input.js
@@ -46,7 +46,8 @@ var InputComponent = React.createClass({
                onChange={this._onChange}
                onBlur={this.props.onBlur}
                value={this.state.value}
-               readOnly={this.props.readonly} />
+               readOnly={this.props.readonly}
+               autoComplete="off" />
       </div>
     );
   }

--- a/client/js/app/components/common/react_select.js
+++ b/client/js/app/components/common/react_select.js
@@ -320,7 +320,8 @@ var ReactSelect = React.createClass({
                aria-owns={this.props.id + '-scrollpane'}
                aria-label={this.props.title || "Select value"}
                aria-selected={(this.props.value && this.props.value.length) ? true : undefined}
-               aria-live="polite" />
+               aria-live="polite"
+               autoComplete="off" />
         {scrollpane}
       </div>
     );

--- a/client/js/app/components/common/relative_picker.js
+++ b/client/js/app/components/common/relative_picker.js
@@ -63,7 +63,8 @@ var RelativePicker = React.createClass({
                    classes="amount"
                    onChange={this.setRelativeTime}
                    placeholder="e.g. 1"
-                   value={this.props.time.amount || ""} />
+                   value={this.props.time.amount || ""}
+                   autoComplete="off" />
           </div>
           <div className="col-xs-5 form-collapse-left" id="sub-interval-type">
             <Select label={false}

--- a/dist/keen-explorer.js
+++ b/dist/keen-explorer.js
@@ -61868,7 +61868,7 @@
 	        React.createElement(
 	          'div',
 	          { className: 'search-box' },
-	          React.createElement('input', { type: 'text', name: 'search', ref: 'search-box', placeholder: 'Search...', onChange: this.setSearchText }),
+	          React.createElement('input', { type: 'text', name: 'search', ref: 'search-box', placeholder: 'Search...', onChange: this.setSearchText, autoComplete: 'off' }),
 	          React.createElement('span', { className: 'glyphicon glyphicon-search icon' })
 	        ),
 	        React.createElement(
@@ -86157,7 +86157,8 @@
 	        'aria-owns': this.props.id + '-scrollpane',
 	        'aria-label': this.props.title || "Select value",
 	        'aria-selected': this.props.value && this.props.value.length ? true : undefined,
-	        'aria-live': 'polite' }),
+	        'aria-live': 'polite',
+	        autoComplete: 'off' }),
 	      scrollpane
 	    );
 	  }
@@ -86276,7 +86277,8 @@
 	        onChange: this._onChange,
 	        onBlur: this.props.onBlur,
 	        value: this.state.value,
-	        readOnly: this.props.readonly })
+	        readOnly: this.props.readonly,
+	        autoComplete: 'off' })
 	    );
 	  }
 	
@@ -87182,7 +87184,8 @@
 	        onChange: this.props.onChange,
 	        onBlur: this.handleOnBlur,
 	        onFocus: this.onFocus,
-	        placeholder: this.props.placeholder }),
+	        placeholder: this.props.placeholder,
+	        autoComplete: 'off' }),
 	      errorMsg
 	    );
 	  }
@@ -90574,7 +90577,8 @@
 	            classes: 'amount',
 	            onChange: this.setRelativeTime,
 	            placeholder: 'e.g. 1',
-	            value: this.props.time.amount || "" })
+	            value: this.props.time.amount || "",
+	            autoComplete: 'off' })
 	        ),
 	        React.createElement(
 	          'div',
@@ -91125,7 +91129,8 @@
 	        onChange: this.setValueState,
 	        onBlur: this.handleChangeWithEvent,
 	        placeholder: this.getInputPlaceholder(),
-	        readOnly: this.props.filter.coercion_type === 'Null' });
+	        readOnly: this.props.filter.coercion_type === 'Null',
+	        autoComplete: 'off' });
 	    }
 	
 	    return React.createElement(
@@ -91188,7 +91193,8 @@
 	          name: 'coordinates.0',
 	          className: 'form-control',
 	          value: this.props.filter.property_value.coordinates[0] || "",
-	          onChange: this.props.handleChange })
+	          onChange: this.props.handleChange,
+	          autoComplete: 'off' })
 	      ),
 	      React.createElement(
 	        'div',
@@ -91202,7 +91208,8 @@
 	          name: 'coordinates.1',
 	          className: 'form-control',
 	          value: this.props.filter.property_value.coordinates[1] || "",
-	          onChange: this.props.handleChange })
+	          onChange: this.props.handleChange,
+	          autoComplete: 'off' })
 	      ),
 	      React.createElement(
 	        'div',
@@ -91216,7 +91223,8 @@
 	          name: 'max_distance_miles',
 	          className: 'form-control',
 	          value: this.props.filter.property_value.max_distance_miles || "",
-	          onChange: this.props.handleChange })
+	          onChange: this.props.handleChange,
+	          autoComplete: 'off' })
 	      )
 	    );
 	  }


### PR DESCRIPTION
## What does this PR do?

This PR disables browser autocomplete for all `<input type="text">` fields.

Here's a screenshot of the issue being addressed:
<img width="343" alt="screen shot 2017-03-17 at 4 57 28 pm" src="https://cloud.githubusercontent.com/assets/180438/24066815/e6756fb8-0b32-11e7-9936-3b22dcd796d1.png">


## Related Issues
https://github.com/keen/explorer/issues/158