### PR TITLE
Add 'with_actors' checkbox for funnel queries

### DIFF
--- a/client/js/app/components/explorer/query_builder/funnels/funnel_step.js
+++ b/client/js/app/components/explorer/query_builder/funnels/funnel_step.js
@@ -134,6 +134,10 @@ var FunnelStep = React.createClass({
           <label className="block-label">
             <input name="inverted" type="checkbox" checked={this.props.step.inverted} onChange={this.handleCheckboxChange} /> Inverted Step
           </label>
+          <label className="block-label">
+            <input name="with_actors" type="checkbox" checked={this.props.step.with_actors} onChange={this.handleCheckboxChange} /> With actors
+          </label>
+
           <hr />
           {remove}
         </div>

--- a/client/js/app/components/explorer/visualization/chart.js
+++ b/client/js/app/components/explorer/visualization/chart.js
@@ -73,9 +73,7 @@ var Chart = React.createClass({
     var extractionFields = this.props.model.extractionFields;
 
     if (ExplorerUtils.isJSONViz(this.props.model)) {
-      var content = FormatUtils.prettyPrintJSON({
-        result: this.props.model.response.result
-      });
+      var content = FormatUtils.prettyPrintJSON(this.props.model.response);
       chartContent = (
           <textarea ref='jsonViz' className="json-view" value={content} readOnly />
           );

--- a/client/js/app/stores/ExplorerStore.js
+++ b/client/js/app/stores/ExplorerStore.js
@@ -95,6 +95,7 @@ function _defaultStep() {
     filters: [],
     optional: false,
     inverted: false,
+    with_actors: false,
     active: false,
     isValid: true,
     errors: []

--- a/client/js/app/utils/FunnelUtils.js
+++ b/client/js/app/utils/FunnelUtils.js
@@ -11,7 +11,8 @@ var STEP_PARAMS = [
   'timezone',
   'filters',
   'optional',
-  'inverted'
+  'inverted',
+  'with_actors'
 ];
 module.exports = {
 

--- a/client/js/app/utils/FunnelUtils.js
+++ b/client/js/app/utils/FunnelUtils.js
@@ -24,7 +24,7 @@ module.exports = {
       params.filters = _.map(params.filters, function(filter) {
         return FilterUtils.queryJSON(filter, TimeframeUtils.getTimezoneOffset(params.timezone)); 
       });
-     
+
       _.remove(params.filters, _.isEmpty);
     }
 
@@ -51,7 +51,8 @@ module.exports = {
 
     step.inverted = (step.inverted === true || step.inverted === "true");
     step.optional = (step.optional === true || step.optional === "true");
-    
+    step.with_actors = (step.with_actors === true || step.with_actors === "true");
+
     return step;
   }
   

--- a/client/js/app/validations/StepValidations.js
+++ b/client/js/app/validations/StepValidations.js
@@ -65,4 +65,15 @@ module.exports = {
 
   },
 
+  with_actors: {
+
+    msg: '"with_actors" must be set to either true or false',
+
+    validate: function(model) {
+      if (FormatUtils.isNullOrUndefined(model.inverted)) return false;
+      return typeof model.inverted === 'boolean';
+    }
+
+  },
+
 };

--- a/client/js/app/validations/StepValidations.js
+++ b/client/js/app/validations/StepValidations.js
@@ -70,8 +70,8 @@ module.exports = {
     msg: '"with_actors" must be set to either true or false',
 
     validate: function(model) {
-      if (FormatUtils.isNullOrUndefined(model.inverted)) return false;
-      return typeof model.inverted === 'boolean';
+      if (FormatUtils.isNullOrUndefined(model.with_actors)) return false;
+      return typeof model.with_actors === 'boolean';
     }
 
   },

--- a/client/js/app/validations/StepValidations.js
+++ b/client/js/app/validations/StepValidations.js
@@ -5,9 +5,9 @@ var SharedValidators = require('./SharedValidators');
 module.exports = {
 
   event_collection: {
-    
+
     msg: 'Choose an Event Collection.',
-    
+
     validate: function(model) {
       return (typeof model.event_collection ==='string' && model.event_collection.length > 0);
     }

--- a/dist/keen-explorer.js
+++ b/dist/keen-explorer.js
@@ -86342,8 +86342,8 @@
 	    msg: '"with_actors" must be set to either true or false',
 	
 	    validate: function validate(model) {
-	      if (FormatUtils.isNullOrUndefined(model.inverted)) return false;
-	      return typeof model.inverted === 'boolean';
+	      if (FormatUtils.isNullOrUndefined(model.with_actors)) return false;
+	      return typeof model.with_actors === 'boolean';
 	    }
 	
 	  }

--- a/dist/keen-explorer.js
+++ b/dist/keen-explorer.js
@@ -60673,7 +60673,7 @@
 	var FilterUtils = __webpack_require__(/*! ./FilterUtils */ 338);
 	var TimeframeUtils = __webpack_require__(/*! ./TimeframeUtils */ 341);
 	
-	var STEP_PARAMS = ['event_collection', 'actor_property', 'timeframe', 'interval', 'timezone', 'filters', 'optional', 'inverted'];
+	var STEP_PARAMS = ['event_collection', 'actor_property', 'timeframe', 'interval', 'timezone', 'filters', 'optional', 'inverted', 'with_actors'];
 	module.exports = {
 	
 	  stepJSON: function stepJSON(step) {
@@ -84592,9 +84592,7 @@
 	    var extractionFields = this.props.model.extractionFields;
 	
 	    if (ExplorerUtils.isJSONViz(this.props.model)) {
-	      var content = FormatUtils.prettyPrintJSON({
-	        result: this.props.model.response.result
-	      });
+	      var content = FormatUtils.prettyPrintJSON(this.props.model.response);
 	      chartContent = React.createElement('textarea', { ref: 'jsonViz', className: 'json-view', value: content, readOnly: true });
 	    } else if (ExplorerUtils.isTableViz(this.props.model) && extractionFields.length > 0) {
 	      var model = _.cloneDeep(this.props.model);
@@ -86331,6 +86329,17 @@
 	  inverted: {
 	
 	    msg: 'You must select whether this step is inverted.',
+	
+	    validate: function validate(model) {
+	      if (FormatUtils.isNullOrUndefined(model.inverted)) return false;
+	      return typeof model.inverted === 'boolean';
+	    }
+	
+	  },
+	
+	  with_actors: {
+	
+	    msg: '"with_actors" must be set to either true or false',
 	
 	    validate: function validate(model) {
 	      if (FormatUtils.isNullOrUndefined(model.inverted)) return false;

--- a/dist/keen-explorer.js
+++ b/dist/keen-explorer.js
@@ -60712,6 +60712,7 @@
 	
 	    step.inverted = step.inverted === true || step.inverted === "true";
 	    step.optional = step.optional === true || step.optional === "true";
+	    step.with_actors = step.with_actors === true || step.with_actors === "true";
 	
 	    return step;
 	  }
@@ -85468,6 +85469,7 @@
 	    filters: [],
 	    optional: false,
 	    inverted: false,
+	    with_actors: false,
 	    active: false,
 	    isValid: true,
 	    errors: []
@@ -88136,6 +88138,12 @@
 	          { className: 'block-label' },
 	          React.createElement('input', { name: 'inverted', type: 'checkbox', checked: this.props.step.inverted, onChange: this.handleCheckboxChange }),
 	          ' Inverted Step'
+	        ),
+	        React.createElement(
+	          'label',
+	          { className: 'block-label' },
+	          React.createElement('input', { name: 'with_actors', type: 'checkbox', checked: this.props.step.with_actors, onChange: this.handleCheckboxChange }),
+	          ' With actors'
 	        ),
 	        React.createElement('hr', null),
 	        remove

--- a/test/support/TestHelpers.js
+++ b/test/support/TestHelpers.js
@@ -92,6 +92,7 @@ module.exports = {
       filters: [],
       optional: false,
       inverted: false,
+      with_actors: false,
       active: false,
       isValid: true,
       errors: []

--- a/test/unit/stores/ExplorerStoreSpec.js
+++ b/test/unit/stores/ExplorerStoreSpec.js
@@ -1280,6 +1280,7 @@ describe('stores/ExplorerStore', function() {
           filters: [],
           optional: false,
           inverted: false,
+          with_actors: false,
           active: true,
           isValid: false,
           errors: [

--- a/test/unit/utils/FunnelUtilsSpec.js
+++ b/test/unit/utils/FunnelUtilsSpec.js
@@ -120,6 +120,34 @@ describe('utils/FunnelUtils', function() {
         });
         assert.strictEqual(result.optional, false);
       });
+
+      it('should properly format true boolean values from API for the "with_actors" property', function () {
+        var result = FunnelUtils.formatQueryParams({
+          with_actors: true
+        });
+        assert.strictEqual(result.with_actors, true);
+      });
+
+      it('should properly format string true as boolean values from API for the "with_actors" property', function () {
+        var result = FunnelUtils.formatQueryParams({
+          with_actors: "true"
+        });
+        assert.strictEqual(result.with_actors, true);
+      });
+
+      it('should properly format false boolean values from API for the "with_actors" property', function () {
+        var result = FunnelUtils.formatQueryParams({
+          with_actors: false
+        });
+        assert.strictEqual(result.with_actors, false);
+      });
+
+      it('should properly format string false as boolean values from API for the "with_actors" property', function () {
+        var result = FunnelUtils.formatQueryParams({
+          with_actors: "false"
+        });
+        assert.strictEqual(result.with_actors, false);
+      });
     });
   });
 });

--- a/test/unit/validations/StepValidationsSpec.js
+++ b/test/unit/validations/StepValidationsSpec.js
@@ -61,4 +61,32 @@ describe('validations/StepValidations', function() {
     });
   });
 
+  describe('with_actors', function () {
+    it('has an error message', function () {
+      var errorMessage = StepValidations.with_actors.msg;
+      assert.equal(errorMessage, '"with_actors" must be set to either true or false');
+    });
+
+    it('returns true when the value is true', function () {
+      assert.isTrue(StepValidations.with_actors.validate({ with_actors: true }));
+    });
+
+    it('returns true when the value is false', function () {
+      assert.isTrue(StepValidations.with_actors.validate({ with_actors: false }));
+    });
+
+    it('returns false when the value is null', function () {
+      assert.isFalse(StepValidations.with_actors.validate({ with_actors: null }));
+    });
+
+    it('returns false when the value is undefined', function () {
+      assert.isFalse(StepValidations.with_actors.validate({ with_actors: undefined }));
+    });
+
+    it('returns false when the value is not a boolean', function () {
+      assert.isFalse(StepValidations.with_actors.validate({ with_actors: 'nope' }));
+    });
+  });
+
+
 });


### PR DESCRIPTION
## What does this PR do?

This adds a 'With Actors' property for funnel steps. This also changes the explorer so it displays the _whole_ response in the "JSON" visualization so we can view said actors.

## Screenshots

<img width="974" alt="screen shot 2017-06-08 at 9 43 19 am" src="https://user-images.githubusercontent.com/638351/26937570-f7b81856-4c2e-11e7-872f-6bb928e07b52.png">
