### PR TITLE
fix: 🐛 optional order field cannot be empty string

### DIFF
--- a/lib/js/app/components/explorer/GroupBy.js
+++ b/lib/js/app/components/explorer/GroupBy.js
@@ -77,7 +77,7 @@ class GroupBy extends Component {
               label: orderBy.direction,
               value: orderBy.direction,
             }}
-            options={['', 'ASC', 'DESC'].map(item => ({ label: item, value: item }) )}
+            options={['ASC', 'DESC'].map(item => ({ label: item, value: item }) )}
             onChange={(value) => {
               updateUI({
                 orderBy: {


### PR DESCRIPTION
https://github.com/keen/keen/issues/48