### PR TITLE
fix: 🐛 prevent reset query after selecting same event stream

### DIFF
--- a/lib/js/app/queryCreator/components/EventCollection/EventCollection.test.tsx
+++ b/lib/js/app/queryCreator/components/EventCollection/EventCollection.test.tsx
@@ -120,3 +120,25 @@ test('renders empty search results', () => {
     getByText('query_creator_event_collection.empty_search_results')
   ).toBeInTheDocument();
 });
+
+test('do not calls "onChange" handler for selecting same event collection', () => {
+  const storeState = {
+    events: {
+      collections: ['clicks', 'logins', 'purchases'],
+    },
+  };
+  const {
+    wrapper: { getByTestId, getByText },
+    props,
+  } = render(storeState, {
+    collection: 'clicks',
+  });
+
+  const propertyField = getByTestId('dropable-container');
+  fireEvent.click(propertyField);
+
+  const property = getByText('clicks');
+  fireEvent.click(property);
+
+  expect(props.onChange).not.toHaveBeenCalled();
+});

--- a/lib/js/app/queryCreator/components/EventCollection/EventCollection.tsx
+++ b/lib/js/app/queryCreator/components/EventCollection/EventCollection.tsx
@@ -174,7 +174,9 @@ const EventCollection: FC<Props> = ({
                 items={collectionsList}
                 setActiveItem={(_item, idx) => selectionIndex === idx}
                 onClick={(_e, { value }) => {
-                  onChange(value);
+                  if (collection !== value) {
+                    onChange(value);
+                  }
                   setCollectionsList(options);
                 }}
               />


### PR DESCRIPTION
Related with JIRA FEE-193 ticket.