### PR TITLE
fix: 🐛 Widget picker z-index changed to be bigger than range slider z-index

### DIFF
--- a/src/components/EditorVisualization/EditorVisualization.styles.ts
+++ b/src/components/EditorVisualization/EditorVisualization.styles.ts
@@ -8,4 +8,5 @@ export const Container = styled.div`
 export const PickerContainer = styled.div`
   padding: 10px;
   flex-shrink: 0;
+  z-index: 4;
 `;


### PR DESCRIPTION
Closes: [FEE-505](https://metakeen.atlassian.net/browse/FEE-505)