### PR TITLE
fix: 🐛 add styling to Query Summary filters

### DIFF
--- a/src/components/QuerySummary/components/FunnelStep/FunnelStep.tsx
+++ b/src/components/QuerySummary/components/FunnelStep/FunnelStep.tsx
@@ -101,7 +101,9 @@ const FunnelStep: FC<Props> = ({ step, index, label }) => {
                       {t('query_summary.applied_filters')}
                     </BodyText>
                   </StyledTable.Label>
-                  <StyledTable.Value>{filters.length}</StyledTable.Value>
+                  <StyledTable.Value>
+                    <BodyText variant="body2">{filters.length}</BodyText>
+                  </StyledTable.Value>
                 </StyledTable.Row>
               )}
             </StyledTable.Body>


### PR DESCRIPTION
https://metakeen.atlassian.net/browse/FEE-559

<img width="743" alt="Screenshot 2021-04-13 at 13 28 23" src="https://user-images.githubusercontent.com/23423731/114545571-688e1b80-9c5c-11eb-8c2c-906e75fdce85.png">


