### PR TITLE
fix: 🐛 Tooltip position in navigation changed

### DIFF
--- a/src/components/BrowserQueryMenu/BrowserQueryMenu.tsx
+++ b/src/components/BrowserQueryMenu/BrowserQueryMenu.tsx
@@ -80,6 +80,7 @@ const BrowserQueryMenu: FC<Props> = ({ onEditQuery, onRemoveQuery }) => {
       <ContextActions data-testid="context-buttons">
         <MousePositionedTooltip
           isActive={!actionsMenu}
+          tooltipPinPlacement="bottom-left"
           renderContent={() =>
             menuTooltip(t('browser_query_menu.settings_tooltip'))
           }
@@ -98,6 +99,7 @@ const BrowserQueryMenu: FC<Props> = ({ onEditQuery, onRemoveQuery }) => {
         </MousePositionedTooltip>
         <MousePositionedTooltip
           isActive={!actionsMenu}
+          tooltipPinPlacement="bottom-left"
           renderContent={() =>
             menuTooltip(t('browser_query_menu.share_tooltip'))
           }
@@ -114,6 +116,7 @@ const BrowserQueryMenu: FC<Props> = ({ onEditQuery, onRemoveQuery }) => {
         </MousePositionedTooltip>
         <MousePositionedTooltip
           isActive={!actionsMenu}
+          tooltipPinPlacement="bottom-left"
           renderContent={() =>
             menuTooltip(t('browser_query_menu.actions_tooltip'))
           }

--- a/src/components/EditorNavigation/EditorNavigation.tsx
+++ b/src/components/EditorNavigation/EditorNavigation.tsx
@@ -140,6 +140,7 @@ const EditorNavigation: FC<Props> = ({ onSaveQuery }) => {
       <Menu>
         <MousePositionedTooltip
           isActive={!actionsMenu}
+          tooltipPinPlacement="bottom-left"
           renderContent={() => menuTooltip(t('editor.settings_tooltip'))}
         >
           <MenuItem position="relative">
@@ -161,6 +162,7 @@ const EditorNavigation: FC<Props> = ({ onSaveQuery }) => {
 
         <MousePositionedTooltip
           isActive={!actionsMenu}
+          tooltipPinPlacement="bottom-left"
           renderContent={() => menuTooltip(t('actions_menu.share_query'))}
         >
           <MenuItem position="relative" data-testid="share-query">
@@ -179,6 +181,7 @@ const EditorNavigation: FC<Props> = ({ onSaveQuery }) => {
         </MousePositionedTooltip>
         <MousePositionedTooltip
           isActive={!actionsMenu}
+          tooltipPinPlacement="bottom-left"
           renderContent={() => menuTooltip(t('editor.actions_tooltip'))}
         >
           <MenuItem position="relative" ref={actionsContainer}>


### PR DESCRIPTION
Fixes a problem with tooltip inside navigation buttons showing out of viewport